### PR TITLE
chore: migrate text generation to Gemini (shim + deps)

### DIFF
--- a/.github/workflows/monthly_calendar.yml
+++ b/.github/workflows/monthly_calendar.yml
@@ -60,7 +60,8 @@ jobs:
     - name: 🌙 Generate lunar_calendar.json
       if: env.RUN_CALENDAR == 'yes'
       env:
-        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} # here
+        #OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} # here
+        GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         WORK_DATE:      ${{ env.WORK_DATE }}
       run: |
         # Если WORK_DATE задана → «переопределяем» pendulum.today()

--- a/.github/workflows/monthly_calendar.yml
+++ b/.github/workflows/monthly_calendar.yml
@@ -60,7 +60,7 @@ jobs:
     - name: 🌙 Generate lunar_calendar.json
       if: env.RUN_CALENDAR == 'yes'
       env:
-        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }} # here
         WORK_DATE:      ${{ env.WORK_DATE }}
       run: |
         # Если WORK_DATE задана → «переопределяем» pendulum.today()

--- a/gen_lunar_calendar.py
+++ b/gen_lunar_calendar.py
@@ -24,7 +24,7 @@ TZ = pendulum.timezone("Asia/Nicosia")
 # ───── GPT (по возможности) ────────────────────────────────────────────────
 try:
     from openai import OpenAI
-    GPT = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+    GPT = OpenAI(api_key=os.getenv("OPENAI_API_KEY")) #здесь исправить? 
 except Exception:
     GPT = None
 # ───────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Migration: OpenAI → Gemini

@codex помоги, пожалуйста, найти все места для миграции:
1) файлы/строки с import openai / from openai / ChatCompletion / OPENAI_API_KEY / gpt-3 / gpt-4 / chatgpt;
2) GitHub Actions, где ещё прокидывается OPENAI_API_KEY — предложи патч на GEMINI_API_KEY + установку google-generativeai;
3) проверь requirements/pyproject: добавить google-generativeai, удалить openai (если не используется);
4) дай список конкретных изменений по файлам (и лучше готовые дифф-патчи), чтобы все вызовы шли через наш gpt.py;
5) особенно проверь job “Monthly calendar”.

Цель: весь текст теперь генерируем через модуль gpt.py (Gemini).
