### PR TITLE
fix: stop badging weak-wind KLD forecasts as storm warnings

### DIFF
--- a/format_v2.py
+++ b/format_v2.py
@@ -11,6 +11,12 @@ from visibility_context import (
     visibility_condition_from_text,
     visibility_reason,
 )
+from weather_text import STORM_GUST_MS as _STORM_GUST_MS
+from weather_text import clause_has_confirmed_storm as _clause_has_confirmed_storm
+from weather_text import extract_max_gust_ms as _max_gust_ms
+from weather_text import extract_max_wind_ms as _max_wind_ms
+from weather_text import has_confirmed_storm_word as _has_explicit_storm_text
+from weather_text import split_clauses as _split_storm_clauses
 
 
 def _is_sep(line: str) -> bool:
@@ -78,20 +84,18 @@ def _first_line_contains(lines: list[str], word: str) -> str:
         low = s.lower()
         if s.startswith("#"):
             break
-        if "без шторма" in low or "доброе утро" in low or s.startswith("🌾"):
+        if "доброе утро" in low or s.startswith("🌾"):
             continue
         if not (s.startswith("⚠️") or "предупреждение" in low):
             continue
-        if word.lower() in low and "погода на завтра" not in low:
+        if word.lower() not in low or "погода на завтра" in low:
+            continue
+        # Clause-aware: a negation/hedge in one clause of the line must not
+        # discard a genuine confirmation in another clause, e.g. "Риск шторма
+        # невысок, но штормовое предупреждение действует у моря."
+        if any(_clause_has_confirmed_storm(clause) for clause in _split_storm_clauses(s)):
             return s
     return ""
-
-
-def _has_explicit_storm_text(text: str) -> bool:
-    low = _plain(text).lower()
-    if "без шторма" in low:
-        low = low.replace("без шторма", "")
-    return "шторм" in low
 
 
 def _normalize_weather_line(line: str) -> str:
@@ -418,7 +422,13 @@ def _common_sup_water_line(lines: list[str], *, has_storm: bool = False) -> str:
     if not has_water_sport:
         return ""
     max_wind = _max_wind_ms(text)
-    stormy = has_storm or (isinstance(max_wind, (int, float)) and max_wind >= 15)
+    # The storm-tier water guidance keys on a confirmed storm or a real gust at
+    # the threshold — never on average wind alone. Strong average wind still
+    # makes the guidance strict, but via the "risky" branch below, not the
+    # storm branch (contract: water caution may be strict on wind, but is not
+    # labelled a storm just because the average wind is high).
+    max_gust = _max_gust_ms(text)
+    stormy = has_storm or (isinstance(max_gust, (int, float)) and max_gust >= _STORM_GUST_MS)
     if stormy:
         wave = _format_measure_range(wave_range, "м")
         wave_part = f"волна {wave}, но " if wave else ""
@@ -566,14 +576,11 @@ def _morning_region_context_from_pairs(values: object) -> str:
     )
 
 
-def _max_wind_ms(text: str) -> float | None:
-    values: list[float] = []
-    for m in re.finditer(r"(?:порывы\s*(?:до\s*)?)?(\d+(?:[\.,]\d+)?)\s*м/с", text, flags=re.I):
-        try:
-            values.append(float(m.group(1).replace(",", ".")))
-        except Exception:
-            continue
-    return max(values) if values else None
+# _max_wind_ms / _max_gust_ms are imported from weather_text (the single shared
+# parser). _max_wind_ms is the average/max wind for the softer windy /
+# water-caution / comfort cues; _max_gust_ms counts only "порыв …" values and
+# is the ONLY input to the storm-gust threshold — a strong average wind must
+# never be read as a storm gust.
 
 
 def _has_actual_precipitation(text: str) -> bool:
@@ -709,7 +716,10 @@ def _evening_flags(lines: list[str], *, storm: str) -> dict[str, bool]:
     text = "\n".join(effective_lines)
     max_temp = _max_temperature_c(text)
     max_wind = _max_wind_ms(text)
-    storm_gust = isinstance(max_wind, (int, float)) and max_wind >= 15
+    # storm_gust keys on the actual gust ("порыв …"), never on average wind:
+    # "ветер 16 м/с, порывы до 14 м/с" is NOT a storm (gust 14 < threshold).
+    max_gust = _max_gust_ms(text)
+    storm_gust = isinstance(max_gust, (int, float)) and max_gust >= _STORM_GUST_MS
     visibility_condition = visibility_condition_from_text(text)
     return {
         "storm": bool(storm) or _has_explicit_storm_text(text) or storm_gust,
@@ -719,6 +729,7 @@ def _evening_flags(lines: list[str], *, storm: str) -> dict[str, bool]:
         "heat": isinstance(max_temp, (int, float)) and max_temp >= 35,
         "max_temp": max_temp,
         "max_wind": max_wind,
+        "max_gust": max_gust,
         "storm_gust": storm_gust,
         "wind": _has_any(text, ("порыв", "сильный ветер", "шторм")) or (isinstance(max_wind, (int, float)) and max_wind >= 8),
         "waves": _has_any(text, ("волна", "волн", "🌊")) and _has_any(text, ("0.8 м", "0.9 м", "1.0 м", "1 м", "1.1 м", "1.2 м")),
@@ -760,7 +771,8 @@ def _evening_main_scenario(flags: dict[str, bool], score_line: str) -> str:
 
 def _evening_nuance(flags: dict[str, bool], has_sea: bool, has_region: bool) -> str:
     if flags["storm"]:
-        gust = flags.get("max_wind")
+        # Report the actual gust ("порывы до N м/с"), not the average wind.
+        gust = flags.get("max_gust")
         if isinstance(gust, (int, float)):
             return f"⚠️ Главный нюанс: на открытом берегу и пирсах порывы до {_fmt_num(gust)} м/с."
         return "⚠️ Главный нюанс: открытый берег, пирсы и водные активности — только после фактической проверки условий."

--- a/kld_informative_cover.py
+++ b/kld_informative_cover.py
@@ -9,6 +9,10 @@ import re
 from pathlib import Path
 from typing import Any, Mapping
 
+import weather_text
+from weather_text import clause_has_confirmed_storm as _clause_has_confirmed_storm
+from weather_text import split_clauses as _split_clauses
+
 
 RENDERER_VERSION = "kld_local_informative_cover_v1"
 _NUMBER = r"-?\d+(?:[.,]\d+)?"
@@ -28,35 +32,96 @@ _EDITORIAL_LINE_RE = re.compile(
     r"(?:\s+[^:]{1,32})?\s*:",
     re.IGNORECASE,
 )
-_STORM_NEGATION_RE = re.compile(
-    r"(?:штормов\w*\s+предупрежден\w*\s+нет|"
-    r"шторм\w*\s+не\s+ожида\w*|без\s+шторма|"
-    r"риск\s+шторма\s+низк\w*|шторм\w*\s+не\s+подтвержд\w*|"
-    r"гроз\w*\s+не\s+ожида\w*)",
+# "шторм" word/negation/uncertainty detection is shared with format_v2.py,
+# safe_test_post.py and post_kld.py via weather_text.clause_has_confirmed_storm,
+# so all four use one contract. "гроза" (thunderstorm) is a separate concept
+# only this module tracks; it is evaluated independently of "шторм" (a negated
+# storm must not cancel a confirmed thunderstorm in the same/other clause, and
+# vice versa) using the same bounded-gap, actor-vs-cancellation discipline and
+# the same two gap directions as precipitation (a cue-before-term gap must not
+# cross a comma, so "Шторм возможен, гроза ожидается." keeps the thunderstorm).
+_THUNDERSTORM_GAP_AFTER = r"(?:(?!гроз\w*)[^.!?\n]){0,40}?"
+_THUNDERSTORM_GAP_BEFORE = r"(?:(?!гроз\w*)[^.!?\n,]){0,40}?"
+_THUNDERSTORM_NEGATION_RE = re.compile(
+    rf"гроз\w*{_THUNDERSTORM_GAP_AFTER}\b(?:не\s+(?:ожида\w*|будет|прогнозир\w*|предвид\w*|подтвержд\w*)|"
+    r"маловероят\w*|исключ(?:ён\w*|ен[аоы]\w*))|"
+    r"без\s+гроз\w*|"
+    rf"(?:риск|вероятност\w*){_THUNDERSTORM_GAP_BEFORE}\bгроз\w*{_THUNDERSTORM_GAP_AFTER}"
+    rf"\b(?:низк\w*|невысок\w*|минимал\w*|отсутств\w*)",
     re.IGNORECASE,
 )
-_STORM_UNCERTAIN_RE = re.compile(
-    r"(?:риск|вероятност\w*)\s+(?:шторма|гроз\w*)|"
-    r"(?:шторм|гроз)\w*[^.!?\n]*(?:провер|уточн|возмож|вероятн|не\s+исключ)",
+_THUNDERSTORM_UNCERTAIN_RE = re.compile(
+    rf"гроз\w*{_THUNDERSTORM_GAP_AFTER}\b(?:провер\w*|уточн\w*|возмож\w*|вероятн\w*|не\s+исключ\w*|сохраня\w*)|"
+    rf"(?:возмож\w*|вероятност\w*|риск){_THUNDERSTORM_GAP_BEFORE}\bгроз\w*",
     re.IGNORECASE,
 )
-_STORM_RE = re.compile(r"(?:шторм\w*|⛈|гроз\w*)", re.IGNORECASE)
-_THUNDERSTORM_RE = re.compile(r"(?:⛈|гроз\w*)", re.IGNORECASE)
-_PRECIPITATION_NEGATION_RE = re.compile(
-    r"(?:без\s+осадков|дожд\w*\s+не\s+ожида\w*|преимущественно\s+сух\w*|"
-    r"вероятност\w*\s+дожд\w*\s+низк\w*|осадк\w*\s+не\s+подтвержд\w*|"
-    r"морос\w*\s+не\s+ожида\w*|без\s+морос\w*|"
-    r"вероятност\w*\s+морос\w*\s+низк\w*|морос\w*\s+не\s+подтвержд\w*|"
-    r"снег\w*\s+не\s+ожида\w*|без\s+снег\w*|"
-    r"вероятност\w*\s+снег\w*\s+низк\w*|снег\w*\s+не\s+подтвержд\w*)",
-    re.IGNORECASE,
-)
-_PRECIPITATION_UNCERTAIN_RE = re.compile(
-    r"(?:вероятност\w*\s+(?:дожд|осад|морос|снег)\w*|"
-    r"(?:дожд|осад|морос|снег)\w*[^.!?\n]*"
-    r"(?:провер|уточн|возмож|вероятн|не\s+исключ))",
-    re.IGNORECASE,
-)
+_THUNDERSTORM_WORD_RE = re.compile(r"гроз\w*", re.IGNORECASE)
+_THUNDERSTORM_ICON_RE = re.compile(r"⛈")
+
+# Independent per-type evidence/negation/uncertainty for precipitation: a single
+# global "any negation anywhere in the clause -> drop everything" check used to
+# make "Дождь будет, снега не будет." lose the real rain along with the negated
+# snow. Each type (rain, drizzle, snow, generic precipitation) now has its own
+# regexes, and the term<->cue gap is walled off from the *other* types' stems.
+# Two gap directions:
+#  - term-first ("снега ... не будет"): the cue follows the term, so the gap may
+#    cross commas (parenthetical modifiers: "снега, скорее всего, не будет").
+#  - cue-first ("возможна морось", "риск дождя"): the cue precedes the term, so
+#    the gap must NOT cross a comma, or the cue would bind to a following type
+#    ("Дождь возможен, снег ожидается." must keep snow confirmed).
+# Negation uses the passive participle "исключён/исключена" (fact removed), not
+# a bare "исключ\w*", so the active verb "исключил" ("Снег исключил движение.")
+# stays a confirmation.
+_NEGATION_SUFFIX = r"не\s+(?:ожида\w*|будет|прогнозир\w*|предвид\w*|подтвержд\w*)|маловероят\w*|исключ(?:ён\w*|ен[аоы]\w*)"
+_UNCERTAIN_SUFFIX_AFTER = r"провер\w*|уточн\w*|возмож\w*|вероятн\w*|не\s+исключ\w*|сохраня\w*"
+_PRECIP_GROUP_STEMS = {
+    "rain": ("дожд", "лив"),
+    "drizzle": ("морос",),
+    "snow": ("снег",),
+    "precipitation": ("осадк",),
+}
+
+
+def _precip_gap(group_key: str, *, block_comma: bool, max_len: int = 40) -> str:
+    other_stems = [
+        stem
+        for key, stems in _PRECIP_GROUP_STEMS.items()
+        if key != group_key
+        for stem in stems
+    ]
+    char_class = r"[^.!?\n,]" if block_comma else r"[^.!?\n]"
+    if other_stems:
+        forbidden = "|".join(rf"{stem}\w*" for stem in other_stems)
+        return rf"(?:(?!{forbidden}){char_class}){{0,{max_len}}}?"
+    return rf"{char_class}{{0,{max_len}}}?"
+
+
+def _build_precip_negation_uncertain() -> tuple[dict[str, re.Pattern[str]], dict[str, re.Pattern[str]]]:
+    negation_by_group: dict[str, re.Pattern[str]] = {}
+    uncertain_by_group: dict[str, re.Pattern[str]] = {}
+    for group_key, stems in _PRECIP_GROUP_STEMS.items():
+        gap_after = _precip_gap(group_key, block_comma=False)   # term ... cue
+        gap_before = _precip_gap(group_key, block_comma=True)   # cue ... term
+        negation_parts: list[str] = []
+        uncertain_parts: list[str] = []
+        for stem in stems:
+            negation_parts.append(rf"без\s+{stem}\w*")
+            negation_parts.append(rf"{stem}\w*{gap_after}\b(?:{_NEGATION_SUFFIX})")
+            negation_parts.append(
+                rf"(?:риск|вероятност\w*){gap_before}\b{stem}\w*{gap_after}"
+                rf"\b(?:низк\w*|невысок\w*|минимал\w*|отсутств\w*)"
+            )
+            uncertain_parts.append(rf"{stem}\w*{gap_after}\b(?:{_UNCERTAIN_SUFFIX_AFTER})")
+            uncertain_parts.append(rf"(?:возмож\w*|вероятност\w*){gap_before}\b{stem}\w*")
+        if group_key == "rain":
+            negation_parts.append(r"преимущественно\s+сух\w*")
+        negation_by_group[group_key] = re.compile("|".join(negation_parts), re.IGNORECASE)
+        uncertain_by_group[group_key] = re.compile("|".join(uncertain_parts), re.IGNORECASE)
+    return negation_by_group, uncertain_by_group
+
+
+_PRECIP_NEGATION_RE_BY_GROUP, _PRECIP_UNCERTAIN_RE_BY_GROUP = _build_precip_negation_uncertain()
+
 _RAIN_WORD_RE = re.compile(r"(?:дожд\w*|лив\w*)", re.IGNORECASE)
 _RAIN_ICON_RE = re.compile(r"🌧")
 _SHOWERS_ICON_RE = re.compile(r"🌦")
@@ -64,6 +129,30 @@ _DRIZZLE_RE = re.compile(r"морос\w*", re.IGNORECASE)
 _SNOW_RE = re.compile(r"(?:❄|снег\w*)", re.IGNORECASE)
 _PRECIPITATION_RE = re.compile(r"осад\w*", re.IGNORECASE)
 _STRONG_WIND_RE = re.compile(r"(?:сильн\w*\s+ветер|штормов\w*\s+ветер)", re.IGNORECASE)
+
+
+def _thunderstorm_confirmed(clause: str) -> bool:
+    """Thunderstorm evidence, evaluated independently of "шторм".
+
+    The ⛈ emoji is an unambiguous fact; the word "гроза" is confirmed only
+    when it is neither negated ("Грозы не будет.") nor hedged ("гроза
+    возможна", "риск грозы")."""
+    low = clause.lower()
+    if _THUNDERSTORM_ICON_RE.search(clause):
+        return True
+    if not _THUNDERSTORM_WORD_RE.search(low):
+        return False
+    return not _THUNDERSTORM_NEGATION_RE.search(low) and not _THUNDERSTORM_UNCERTAIN_RE.search(low)
+
+
+def _precip_group_confirmed(group_key: str, clause: str, *, has_evidence: bool) -> bool:
+    if not has_evidence:
+        return False
+    if _PRECIP_NEGATION_RE_BY_GROUP[group_key].search(clause):
+        return False
+    if _PRECIP_UNCERTAIN_RE_BY_GROUP[group_key].search(clause):
+        return False
+    return True
 
 
 def _number(value: object) -> float | None:
@@ -97,43 +186,79 @@ def _factual_weather_truth(message: str) -> dict[str, bool]:
     snow = False
     thunderstorm = False
     strong_wind = False
+    max_gust: float | None = None
 
     for raw_line in message.splitlines():
         line = _HTML_TAG_RE.sub("", raw_line).strip().lower()
         if not line or _EDITORIAL_LINE_RE.match(line):
             continue
 
-        gust_match = _GUST_RE.search(line)
-        gust = _number(gust_match.group(1)) if gust_match else None
+        # Gust value via the single shared parser (weather_text), counting only
+        # "порыв …" — never average wind — so storm_gust below matches the other
+        # layers exactly.
+        gust = weather_text.extract_max_gust_ms(line)
+        if gust is not None:
+            max_gust = gust if max_gust is None else max(max_gust, gust)
+        # strong_wind is a softer "notable wind" cue (>=12 м/с) and can begin
+        # well below the storm threshold — it must never stand in for
+        # storm_gust, which is a strict >=STORM_GUST_MS test derived below.
         if (gust is not None and gust >= 12) or _STRONG_WIND_RE.search(line):
             strong_wind = True
 
-        storm_negated = bool(_STORM_NEGATION_RE.search(line))
-        storm_uncertain = bool(_STORM_UNCERTAIN_RE.search(line))
-        if not storm_negated and not storm_uncertain:
-            if _STORM_RE.search(line):
+        # Split into clauses (sentence punctuation, or ", но"/", а" joining two
+        # independent statements) so a negation in one clause ("Шторма не будет
+        # утром.", "Снега не будет утром.") cannot cancel a genuine confirmation
+        # in a different clause on the same line ("Вечером ожидается шторм.").
+        for raw_clause in _split_clauses(line):
+            clause = raw_clause.strip()
+            if not clause:
+                continue
+
+            # Storm ("шторм") and thunderstorm ("гроза"/⛈) are strictly
+            # independent per clause: "Шторма не будет, гроза ожидается."
+            # confirms thunderstorm ONLY (explicit_storm stays False); "Грозы
+            # не будет, шторм ожидается." confirms the storm ONLY. Neither flag
+            # raises the other — the umbrella "either severe phenomenon" case
+            # is the separate derived `severe_weather` flag computed below.
+            if _clause_has_confirmed_storm(clause):
                 explicit_storm = True
-            if _THUNDERSTORM_RE.search(line):
+            if _thunderstorm_confirmed(clause):
                 thunderstorm = True
 
-        precipitation_negated = bool(_PRECIPITATION_NEGATION_RE.search(line))
-        precipitation_uncertain = bool(_PRECIPITATION_UNCERTAIN_RE.search(line))
-        if precipitation_negated or precipitation_uncertain:
-            continue
+            drizzle_evidence = bool(_DRIZZLE_RE.search(clause))
+            snow_evidence = bool(_SNOW_RE.search(clause))
+            explicit_rain_evidence = bool(_RAIN_WORD_RE.search(clause) or _RAIN_ICON_RE.search(clause))
+            showers_icon = bool(_SHOWERS_ICON_RE.search(clause))
+            rain_evidence = explicit_rain_evidence or (
+                showers_icon and not drizzle_evidence and not snow_evidence
+            )
+            precipitation_evidence = bool(_PRECIPITATION_RE.search(clause))
 
-        line_drizzle = bool(_DRIZZLE_RE.search(line))
-        line_snow = bool(_SNOW_RE.search(line))
-        explicit_rain = bool(_RAIN_WORD_RE.search(line) or _RAIN_ICON_RE.search(line))
-        showers_icon = bool(_SHOWERS_ICON_RE.search(line))
-        line_rain = explicit_rain or (showers_icon and not line_drizzle and not line_snow)
-        line_precipitation = bool(_PRECIPITATION_RE.search(line))
-        rain = rain or line_rain
-        drizzle = drizzle or line_drizzle
-        snow = snow or line_snow
-        actual_precipitation = actual_precipitation or any(
-            (line_rain, line_drizzle, line_snow, line_precipitation)
-        )
+            clause_rain = _precip_group_confirmed("rain", clause, has_evidence=rain_evidence)
+            clause_drizzle = _precip_group_confirmed("drizzle", clause, has_evidence=drizzle_evidence)
+            clause_snow = _precip_group_confirmed("snow", clause, has_evidence=snow_evidence)
+            clause_precipitation = _precip_group_confirmed(
+                "precipitation", clause, has_evidence=precipitation_evidence
+            )
+            rain = rain or clause_rain
+            drizzle = drizzle or clause_drizzle
+            snow = snow or clause_snow
+            actual_precipitation = actual_precipitation or any(
+                (clause_rain, clause_drizzle, clause_snow, clause_precipitation)
+            )
 
+    # Numeric storm scenario: gusts at/above the threshold are a storm even
+    # when the word "шторм" never appears (e.g. "порывы до 16 м/с"). The
+    # threshold is read live from weather_text so an env override + reload is
+    # picked up here exactly as it is in format_v2/safe_test_post/post_kld.
+    storm_gust = max_gust is not None and max_gust >= weather_text.STORM_GUST_MS
+    # storm_badge is what drives the "ШТОРМОВОЕ ПРЕДУПРЕЖДЕНИЕ" cover fact:
+    # a confirmed storm word OR a gust-threshold storm. thunderstorm alone
+    # does NOT raise it (that is a lightning motif, not a storm warning).
+    storm_badge = explicit_storm or storm_gust
+    # severe_weather is the umbrella for the dramatic palette: storm word,
+    # thunderstorm, or gust-threshold storm.
+    severe_weather = explicit_storm or thunderstorm or storm_gust
     return {
         "explicit_storm": explicit_storm,
         "actual_precipitation": actual_precipitation,
@@ -141,6 +266,9 @@ def _factual_weather_truth(message: str) -> dict[str, bool]:
         "drizzle": drizzle,
         "snow": snow,
         "thunderstorm": thunderstorm,
+        "storm_gust": storm_gust,
+        "storm_badge": storm_badge,
+        "severe_weather": severe_weather,
         "strong_wind": strong_wind,
     }
 
@@ -243,7 +371,7 @@ def extract_kld_cover_facts(
             break
 
     facts: list[str] = []
-    if flags["explicit_storm"]:
+    if flags["storm_badge"]:
         facts.append("ШТОРМОВОЕ ПРЕДУПРЕЖДЕНИЕ")
     elif flags["precipitation_display"] != "none":
         precipitation_facts = {
@@ -329,7 +457,10 @@ def _font(size: int, *, bold: bool = False):
 
 def _palette(metadata: Mapping[str, Any]) -> tuple[tuple[int, int, int], tuple[int, int, int], tuple[int, int, int]]:
     weather = metadata["weather"]
-    if weather["explicit_storm"]:
+    # Dramatic backdrop for either severe phenomenon (storm or thunderstorm),
+    # via the derived umbrella flag — a thunderstorm-only day should still read
+    # as severe without overloading explicit_storm.
+    if weather.get("severe_weather"):
         return (32, 46, 59), (73, 91, 105), (190, 204, 211)
     precipitation_display = weather["precipitation_display"]
     if precipitation_display in {"snow", "snow_and_drizzle"}:
@@ -382,7 +513,9 @@ def _draw_weather_graphics(
             dot = (x - 3, y - 3, x + 3, y + 3)
             snow_dots.append(dot)
             draw.ellipse(dot, fill=snow_color)
-    if weather["explicit_storm"]:
+    # Lightning is a thunderstorm motif — driven by the thunderstorm flag, not
+    # by a (possibly storm-only) severe-weather day.
+    if weather.get("thunderstorm"):
         lightning_line = ((850, 615), (805, 710), (850, 700), (790, 825))
         draw.line(lightning_line, fill=lightning_color, width=8)
     if weather["strong_wind"] and not weather["rain"]:
@@ -476,6 +609,10 @@ def render_kld_informative_cover(
     png_info.add_text("weather_flags", json.dumps(weather, ensure_ascii=False, sort_keys=True))
     png_info.add_text("graphics", json.dumps(graphics, ensure_ascii=False, sort_keys=True))
     png_info.add_text("explicit_storm", str(bool(weather["explicit_storm"])).lower())
+    png_info.add_text("thunderstorm", str(bool(weather["thunderstorm"])).lower())
+    png_info.add_text("storm_gust", str(bool(weather.get("storm_gust"))).lower())
+    png_info.add_text("storm_badge", str(bool(weather.get("storm_badge"))).lower())
+    png_info.add_text("severe_weather", str(bool(weather.get("severe_weather"))).lower())
     png_info.add_text("actual_precipitation", str(bool(weather["actual_precipitation"])).lower())
     png_info.add_text("precipitation_display", str(weather["precipitation_display"]))
     png_info.add_text("rain_graphics", str(metadata["rain_graphics"]).lower())

--- a/post_kld.py
+++ b/post_kld.py
@@ -22,6 +22,10 @@ import pendulum
 from telegram import Bot, constants
 
 from post_common import build_message, fx_morning_line  # type: ignore
+from weather_text import STORM_GUST_MS
+from weather_text import clause_has_confirmed_storm as _clause_has_confirmed_storm
+from weather_text import extract_max_gust_ms
+from weather_text import split_clauses as _split_storm_clauses
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
@@ -251,13 +255,9 @@ ZODIAC_GLYPH = {
 }
 
 def _gust_from_line(line: str) -> Optional[float]:
-    values: list[float] = []
-    for raw in re.findall(r"порыв\w*\s*(?:до\s*)?(\d+(?:[\.,]\d+)?)\s*м\s*/?\s*с", str(line or ""), flags=re.I):
-        try:
-            values.append(float(raw.replace(",", ".")))
-        except Exception:
-            pass
-    return max(values) if values else None
+    # Single shared gust parser (weather_text): only "порыв …" values, never
+    # average wind, so the overlay threshold matches the other layers exactly.
+    return extract_max_gust_ms(line)
 
 
 def _is_warning_line(line: str) -> bool:
@@ -288,7 +288,7 @@ def _skip_overlay_storm_line(line: str) -> bool:
 def _storm_overlay_subtitle(line: str) -> str:
     s = re.sub(r"</?b>", "", str(line or "")).strip()
     gust = _gust_from_line(s)
-    if isinstance(gust, (int, float)) and gust >= 15:
+    if isinstance(gust, (int, float)) and gust >= STORM_GUST_MS:
         value = int(gust) if float(gust).is_integer() else gust
         return f"Порывы до {value} м/с"
     s = re.sub(r"^⚠️?\s*", "", s).strip()
@@ -309,21 +309,28 @@ def _extract_storm_warning(msg: str) -> Optional[str]:
     for line in str(msg or "").splitlines():
         stripped = line.strip()
         low = stripped.lower()
-        if not stripped or "без шторма" in low:
+        if not stripped:
             continue
+        # A bare "шторм" substring matched phrasings like "риск шторма невысок" at
+        # any wind speed, badging weak-wind days while genuine strong-gust days
+        # phrased without the word "шторм" got no badge at all. Word/negation
+        # detection is shared (weather_text.py) with format_v2.py and
+        # safe_test_post.py, checked per clause so a negation in one clause of
+        # the line can't cancel a genuine confirmation in another.
+        has_storm_word = any(_clause_has_confirmed_storm(c) for c in _split_storm_clauses(stripped))
         gust = _gust_from_line(stripped)
         if _skip_overlay_storm_line(stripped):
             continue
-        if stripped.startswith("⚠️ Штормовое предупреждение:") or ("шторм" in low and "предупреждение" in low):
+        if has_storm_word and (stripped.startswith("⚠️ Штормовое предупреждение:") or "предупреждение" in low):
             explicit_warning.append(stripped)
             continue
-        if isinstance(gust, (int, float)) and gust >= 15 and _is_warning_line(stripped):
+        if isinstance(gust, (int, float)) and gust >= STORM_GUST_MS and _is_warning_line(stripped):
             warning_gust.append(stripped)
             continue
-        if isinstance(gust, (int, float)) and gust >= 15 and _is_weather_line(stripped):
+        if isinstance(gust, (int, float)) and gust >= STORM_GUST_MS and _is_weather_line(stripped):
             weather_gust.append(stripped)
             continue
-        if "шторм" in low:
+        if has_storm_word:
             fallback.append(stripped)
     for bucket in (explicit_warning, warning_gust, weather_gust, fallback):
         if bucket:

--- a/safe_test_post.py
+++ b/safe_test_post.py
@@ -25,6 +25,11 @@ from visibility_context import (
     visibility_condition_from_text,
     visibility_reason,
 )
+from weather_text import STORM_GUST_MS
+from weather_text import clause_has_confirmed_storm as _line_has_confirmed_storm_word
+from weather_text import extract_max_gust_ms
+from weather_text import has_confirmed_storm_word as _has_confirmed_storm_word
+from weather_text import split_clauses as _split_storm_clauses
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
@@ -375,21 +380,21 @@ def _kld_evening_score_line(v2_text: str) -> str:
     text = _plain(v2_text)
     low = text.lower()
     temps = _numbers(r"(-?\d+(?:[\.,]\d+)?)\s*°", text)
-    gusts = _numbers(r"порывы\s+до\s*(\d+(?:[\.,]\d+)?)", text)
     max_t = max(temps) if temps else None
-    max_gust = max(gusts) if gusts else None
+    # storm gust via the single shared parser: only "порыв …", never avg wind.
+    max_gust = extract_max_gust_ms(text)
     visibility = visibility_condition_from_text(text)
     score = 10.0
     reasons: list[str] = []
 
-    has_warning = "шторм" in low or (isinstance(max_gust, (int, float)) and max_gust >= 15)
+    has_warning = _has_confirmed_storm_word(text) or (isinstance(max_gust, (int, float)) and max_gust >= STORM_GUST_MS)
     has_precip = _has_actual_precipitation(text)
     if has_warning:
         score -= 1.8
     if has_precip:
         score -= 1.1
     if isinstance(max_gust, (int, float)):
-        if max_gust >= 15:
+        if max_gust >= STORM_GUST_MS:
             score -= 1.4
         elif max_gust >= 10:
             score -= 1.0; reasons.append("порывы")
@@ -411,7 +416,7 @@ def _kld_evening_score_line(v2_text: str) -> str:
 
     score = max(1.0, min(10.0, score))
     label = _score_label(score)
-    if has_warning or (isinstance(max_gust, (int, float)) and max_gust >= 15):
+    if has_warning or (isinstance(max_gust, (int, float)) and max_gust >= STORM_GUST_MS):
         if has_precip:
             return f"✨ VayboMeter завтра: {score:.1f}/10 — неустойчивый день: локальные осадки и штормовые порывы."
         return f"✨ VayboMeter завтра: {score:.1f}/10 — день с повышенной осторожностью: штормовые порывы."
@@ -543,8 +548,10 @@ def _kld_reason_conclusion(score: float, reasons: str, v2_text: str) -> str:
     precip = any(x in low for x in ("осадки", "дожд", "морось"))
     cool = any(x in low for x in ("прохлад", "свеж"))
     wind = any(x in low for x in ("порыв", "ветер"))
-    gusts = _numbers(r"порывы\s*(?:до\s*)?(\d+(?:[\.,]\d+)?)", v2_text)
-    warning = "шторм" in low or (gusts and max(gusts) >= 15)
+    max_gust = extract_max_gust_ms(v2_text)
+    warning = _has_confirmed_storm_word(_plain(v2_text)) or (
+        isinstance(max_gust, (int, float)) and max_gust >= STORM_GUST_MS
+    )
     if warning:
         return "День лучше вести с запасным планом: сверить предупреждения утром, у воды не рисковать и держать короткие маршруты."
     if precip and cool and wind:
@@ -718,14 +725,26 @@ def _is_kld_nuance_line(line: str) -> bool:
     return line.strip().startswith(("⚠️ Нюанс:", "⚠️ Главный нюанс:"))
 
 
+# A bare "порыв" substring matched any wind-related nuance line (e.g. "на побережье
+# ощущение меняют порывы"), so a plain 7-9 м/с wind day got its nuance rewritten into
+# "⚠️ Штормовое предупреждение: ...". Promotion now requires either a genuine
+# (non-negated) "шторм" mention or an actual >=STORM_GUST_MS м/с gust value in the
+# line/text. Word/negation detection is shared (weather_text.py) across
+# format_v2.py, safe_test_post.py and post_kld.py so the three don't drift into
+# separate regex contracts again.
+def _line_signals_confirmed_storm(line: str) -> bool:
+    if any(_line_has_confirmed_storm_word(clause) for clause in _split_storm_clauses(line)):
+        return True
+    max_gust = extract_max_gust_ms(line)
+    return isinstance(max_gust, (int, float)) and max_gust >= STORM_GUST_MS
+
+
 def _storm_score_replacement(line: str, full_text: str) -> str:
     if "VayboMeter" not in line or "/10" not in line:
         return line
     plain = _plain(full_text)
-    gusts = _numbers(r"порывы\s*(?:до\s*)?(\d+(?:[\.,]\d+)?)", plain)
-    max_gust = max(gusts) if gusts else None
-    low = plain.lower()
-    if not ("шторм" in low or (isinstance(max_gust, (int, float)) and max_gust >= 15)):
+    max_gust = extract_max_gust_ms(plain)
+    if not (_has_confirmed_storm_word(plain) or (isinstance(max_gust, (int, float)) and max_gust >= STORM_GUST_MS)):
         return line
     replacement = (
         "— неустойчивый день: локальные осадки и штормовые порывы."
@@ -737,9 +756,9 @@ def _storm_score_replacement(line: str, full_text: str) -> str:
 
 def _storm_warning_replacement(line: str) -> str:
     s = _plain(line)
-    gusts = _numbers(r"порыв\w*\s*(?:до\s*)?(\d+(?:[\.,]\d+)?)\s*м/с", s)
-    if gusts:
-        return f"⚠️ Штормовое предупреждение: порывы до {_fmt_num(max(gusts))} м/с."
+    max_gust = extract_max_gust_ms(s)
+    if max_gust is not None:
+        return f"⚠️ Штормовое предупреждение: порывы до {_fmt_num(max_gust)} м/с."
     detail = re.sub(r"^⚠️?\s*", "", s).strip()
     detail = re.sub(r"^(?:Предупреждение|Штормовое(?:\s+предупреждение)?)\s*:?\s*", "", detail, flags=re.I).strip(" .")
     if not detail:
@@ -809,7 +828,7 @@ def _finalize_kld_evening_safe_text(v2_text: str, mode: str) -> str:
         stripped = line.strip()
         if skip_next_specific_warning:
             skip_next_specific_warning = False
-            if "шторм" in stripped.lower() or "порыв" in stripped.lower():
+            if _line_signals_confirmed_storm(stripped):
                 out.append(_storm_warning_replacement(stripped))
                 continue
         if has_compact_nuance and stripped.startswith("⚠️ Главный нюанс:"):
@@ -817,7 +836,7 @@ def _finalize_kld_evening_safe_text(v2_text: str, mode: str) -> str:
         if stripped == "⚠️ <b>Предупреждение</b>" or stripped == "⚠️ Предупреждение":
             skip_next_specific_warning = True
             continue
-        if stripped.startswith("⚠️") and ("шторм" in stripped.lower() or "порыв" in stripped.lower()):
+        if stripped.startswith("⚠️") and _line_signals_confirmed_storm(stripped):
             normalized = _storm_warning_replacement(stripped)
             if normalized not in out:
                 out.append(normalized)

--- a/tools/test_format_v2_evening_kld.py
+++ b/tools/test_format_v2_evening_kld.py
@@ -3,6 +3,7 @@
 """Regression checks for compact KLD FORMAT_V2 evening posts."""
 from __future__ import annotations
 
+import importlib
 import os
 import sys
 import types
@@ -12,6 +13,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+import format_v2  # noqa: E402
 from format_v2 import build_evening_format_v2  # noqa: E402
 
 pendulum_stub = types.ModuleType("pendulum")
@@ -26,8 +28,15 @@ sys.modules.setdefault("telegram", telegram_stub)
 os.environ.setdefault("TELEGRAM_TOKEN_KLG", "test-token")
 os.environ.setdefault("CHANNEL_ID_KLG", "test-channel")
 
-from safe_test_post import _apply_format_v2_safe_postprocess  # noqa: E402
+import safe_test_post  # noqa: E402
+from safe_test_post import (  # noqa: E402
+    _apply_format_v2_safe_postprocess,
+    _has_confirmed_storm_word,
+)
+import post_kld  # noqa: E402
 from post_kld import _extract_storm_warning  # noqa: E402
+import weather_text  # noqa: E402
+import kld_informative_cover  # noqa: E402
 
 
 NORMAL_EVENING = """<b>🌅 Калининградская область: погода на завтра (20.06.2026)</b>
@@ -182,6 +191,50 @@ GUST19_NO_STORM_WORD_EVENING = """<b>🌅 Калининградская обл�
 🌇 Закат завтра: 21:33
 📻 <b>Астрособытия</b>
 🌙 Убывающая Луна, ♐ (92%)
+💚 В плюсе: планы.
+#Калининград #погода #здоровье #море
+"""
+
+
+LOW_GUST_STORM_WORD_EVENING = """<b>🌅 Калининградская область: погода на завтра (03.07.2026)</b>
+✨ VayboMeter завтра: 7.0/10 — рабочий день; риск шторма невысок.
+⚠️ Предупреждение: риск шторма невысок, порывы до 9 м/с.
+Погода: 🏙️ Калининград — 22/16 °C • облачно • 💨 5 м/с • порывы до 9 м/с.
+🌊 <b>Морские города</b>
+Балтийск: 21/16 °C • облачно • 💨 5 м/с • порывы до 9 м/с • 🌊 21 • волна 0.4 м
+———
+🌇 Закат завтра: 21:33
+📻 <b>Астрособытия</b>
+🌙 Растущая Луна, ♐ (72%)
+💚 В плюсе: планы.
+#Калининград #погода #здоровье #море
+"""
+
+
+GUST14_NO_STORM_WORD_EVENING = """<b>🌅 Калининградская область: погода на завтра (22.07.2026)</b>
+✨ VayboMeter завтра: 6.9/10 — рабочий день; порывистый ветер у моря.
+Погода: 🏙️ Калининград — 23/17 °C • облачно • 💨 8 м/с • порывы до 14 м/с.
+🌊 <b>Морские города</b>
+Балтийск: 22/17 °C • облачно • 💨 8 м/с • порывы до 14 м/с • 🌊 19 • волна 1.0 м
+———
+🌇 Закат завтра: 21:20
+📻 <b>Астрособытия</b>
+🌙 Растущая Луна, ♐ (72%)
+💚 В плюсе: планы.
+#Калининград #погода #здоровье #море
+"""
+
+
+def _gust_no_storm_word_evening(gust_ms: int) -> str:
+    return f"""<b>🌅 Калининградская область: погода на завтра (22.07.2026)</b>
+✨ VayboMeter завтра: 6.9/10 — рабочий день; порывистый ветер у моря.
+Погода: 🏙️ Калининград — 23/17 °C • облачно • 💨 8 м/с • порывы до {gust_ms} м/с.
+🌊 <b>Морские города</b>
+Балтийск: 22/17 °C • облачно • 💨 8 м/с • порывы до {gust_ms} м/с • 🌊 19 • волна 1.0 м
+———
+🌇 Закат завтра: 21:20
+📻 <b>Астрособытия</b>
+🌙 Растущая Луна, ♐ (72%)
 💚 В плюсе: планы.
 #Калининград #погода #здоровье #море
 """
@@ -381,6 +434,283 @@ def kld_evening_rain_warning_is_not_storm() -> None:
     assert _extract_storm_warning(RAIN_WARNING_NO_STORM_EVENING) is None
 
 
+def kld_evening_safe_postprocess_does_not_promote_wind_nuance_to_storm() -> None:
+    # Regression: safe_test_post._finalize_kld_evening_safe_text promoted any
+    # "⚠️"-prefixed line containing the word "порыв" to "⚠️ Штормовое
+    # предупреждение: ...", which fired on ordinary wind/rain nuance lines
+    # (e.g. "на побережье ощущение меняют порывы") at 7-9 м/с — this was the
+    # actual source of the storm badge appearing on weak-wind days in
+    # production, upstream of build_evening_format_v2 itself.
+    text = build_evening_format_v2("Калининградская область", RAIN_WARNING_NO_STORM_EVENING)
+    assert "⚠️ Нюанс: у моря дождь и порывы ощущаются резче, чем в городе." in text
+    polished = _apply_format_v2_safe_postprocess(text, "", "", "evening")
+    assert "Штормовое предупреждение" not in polished
+    assert "⚠️ Нюанс: у моря дождь и порывы ощущаются резче, чем в городе." in polished
+
+
+def kld_has_confirmed_storm_word_ignores_negation_from_a_different_line() -> None:
+    # Regression: _has_confirmed_storm_word used to check the whole text at once
+    # (word present AND no negation anywhere), so a negation in one line ("риск
+    # шторма в другой части области невысок") could cancel a real confirmation
+    # in a different line ("Штормовое предупреждение: порывы до 18 м/с.").
+    text = (
+        "Штормовое предупреждение: порывы до 18 м/с.\n"
+        "Риск шторма в другой части области невысок."
+    )
+    assert _has_confirmed_storm_word(text) is True
+
+
+def kld_has_confirmed_storm_word_all_lines_negated_is_false() -> None:
+    text = "Риск шторма невысок.\nШторма не будет."
+    assert _has_confirmed_storm_word(text) is False
+
+
+def kld_has_confirmed_storm_word_confirmed_line_order_independent() -> None:
+    text = (
+        "Шторма не будет.\n"
+        "Штормовое предупреждение: порывы до 18 м/с."
+    )
+    assert _has_confirmed_storm_word(text) is True
+
+
+def kld_storm_negation_handles_modifiers_and_clauses() -> None:
+    # Regression: storm negation required the negation/risk-assessment to sit
+    # immediately after "шторм" (no filler words) and only worked at line
+    # granularity, so hedged phrasings with modifiers ("Шторма точно не
+    # будет.") or a negation and a confirmation sharing one line via ", но"
+    # were misclassified. weather_text.has_confirmed_storm_word is the single
+    # shared contract used by format_v2.py, safe_test_post.py and post_kld.py.
+    cases = [
+        ("Риск шторма в другой части области невысок.", False),
+        ("Шторма точно не будет.", False),
+        ("Шторм, скорее всего, не ожидается.", False),
+        ("Шторма не будет утром. Вечером ожидается шторм.", True),
+        ("Риск шторма невысок, но штормовое предупреждение действует у моря.", True),
+        ("Штормовое предупреждение отменено.", False),
+    ]
+    for text, expected in cases:
+        assert weather_text.has_confirmed_storm_word(text) is expected, (text, expected)
+
+
+def kld_storm_uncertainty_is_not_confirmation() -> None:
+    # A hedged storm mention (possibility/probability/persisting-risk/
+    # check-later/not-ruled-out) must not count as a confirmed storm.
+    for text in (
+        "Шторм возможен.",
+        "Возможен шторм.",
+        "Вероятность шторма 30%.",
+        "Риск шторма сохраняется.",
+        "Шторм следует уточнить утром.",
+        "Шторм не исключён.",
+    ):
+        assert weather_text.clause_has_confirmed_storm(text) is False, text
+
+
+def kld_storm_cancellation_is_scoped_to_the_warning() -> None:
+    # Only the *warning* being cancelled denies a storm. The storm being the
+    # actor of a cancellation ("Шторм отменил...", "Из-за шторма отменены...")
+    # still confirms a storm. Bare "отмен\w*"/"исключ\w*" must not be treated
+    # as fact negation.
+    negated = (
+        "Штормовое предупреждение отменено.",
+        "Штормовое предупреждение снято.",
+        "Штормовое предупреждение не действует.",
+    )
+    confirmed = (
+        "Шторм отменил паромные рейсы.",
+        "Из-за шторма отменены рейсы.",
+    )
+    for text in negated:
+        assert weather_text.clause_has_confirmed_storm(text) is False, text
+    for text in confirmed:
+        assert weather_text.clause_has_confirmed_storm(text) is True, text
+
+
+def kld_first_line_contains_is_clause_aware_morning_and_evening() -> None:
+    # Regression: format_v2._first_line_contains dropped the whole warning line
+    # when a negation matched anywhere in it, so the confirmed second clause of
+    # "Риск шторма невысок, но штормовое предупреждение действует у моря." was
+    # lost. It must survive into both the morning and evening builds.
+    warning = "⚠️ Риск шторма невысок, но штормовое предупреждение действует у моря."
+    body = (
+        "Погода: 🏙️ Калининград — 22/16 °C • облачно • 💨 6 м/с • порывы до 9 м/с.\n"
+        "🌊 <b>Морские города</b>\n"
+        "Балтийск: 21/16 °C • облачно • 💨 6 м/с • порывы до 9 м/с • 🌊 21 • волна 0.4 м\n"
+        "#Калининград #погода #здоровье #море"
+    )
+    evening_source = (
+        "<b>🌅 Калининградская область: погода на завтра (03.07.2026)</b>\n"
+        "✨ VayboMeter завтра: 6.0/10 — с оговорками; ветер у моря.\n"
+        f"{warning}\n{body}"
+    )
+    morning_source = (
+        "<b>🌅 Калининградская область: погода на сегодня (03.07.2026)</b>\n"
+        "✨ VayboMeter: 6.0/10 — с оговорками; ветер у моря.\n"
+        f"{warning}\n{body}"
+    )
+    from format_v2 import _first_line_contains
+
+    assert _first_line_contains(evening_source.splitlines(), "шторм") == warning
+    assert _first_line_contains(morning_source.splitlines(), "шторм") == warning
+
+
+def kld_storm_gust_ms_override_is_consistent_across_layers() -> None:
+    # Regression: format_v2.py read STORM_GUST_MS from the environment, but
+    # safe_test_post.py and post_kld.py still compared against a literal 15,
+    # so overriding the threshold changed the text classification without
+    # changing the image-overlay classification. All three now import
+    # STORM_GUST_MS from weather_text.py.
+    old_value = os.environ.get("STORM_GUST_MS")
+    try:
+        os.environ["STORM_GUST_MS"] = "16"
+        importlib.reload(weather_text)
+        importlib.reload(format_v2)
+        importlib.reload(safe_test_post)
+        importlib.reload(post_kld)
+        assert weather_text.STORM_GUST_MS == 16.0
+
+        gust15 = _gust_no_storm_word_evening(15)
+        gust16 = _gust_no_storm_word_evening(16)
+
+        text15 = format_v2.build_evening_format_v2("Калининградская область", gust15)
+        polished15 = safe_test_post._apply_format_v2_safe_postprocess(text15, "", "", "evening")
+        assert "Штормовое предупреждение" not in polished15
+        assert post_kld._extract_storm_warning(gust15) is None
+
+        text16 = format_v2.build_evening_format_v2("Калининградская область", gust16)
+        assert "⚠️ Главный нюанс: на открытом берегу и пирсах порывы до 16 м/с." in text16
+        assert post_kld._extract_storm_warning(gust16) is not None
+    finally:
+        if old_value is None:
+            os.environ.pop("STORM_GUST_MS", None)
+        else:
+            os.environ["STORM_GUST_MS"] = old_value
+        importlib.reload(weather_text)
+        importlib.reload(format_v2)
+        importlib.reload(safe_test_post)
+        importlib.reload(post_kld)
+        # After restoration, expect whatever the environment actually had: the
+        # caller's own STORM_GUST_MS if one was set, otherwise the 15.0 default.
+        expected_restored = float(old_value) if old_value is not None else 15.0
+        assert weather_text.STORM_GUST_MS == expected_restored
+
+
+def _wind_gust_evening(wind_ms, gust_ms=None) -> str:
+    gust = f" • порывы до {gust_ms} м/с" if gust_ms is not None else ""
+    return (
+        "<b>🌅 Калининградская область: погода на завтра (03.07.2026)</b>\n"
+        "✨ VayboMeter завтра: 6.0/10 — с оговорками; ветер у моря.\n"
+        f"Погода: 🏙️ Калининград — 21/16 °C • облачно • 💨 {wind_ms} м/с{gust}.\n"
+        "🌊 <b>Морские города</b>\n"
+        f"Балтийск: 21/16 °C • облачно • 💨 {wind_ms} м/с{gust} • 🌊 21 • волна 0.4 м\n"
+        "#Калининград #погода #здоровье #море\n"
+    )
+
+
+def _four_layer_storm_state(msg: str) -> dict:
+    """Storm decision as seen by each of the four layers, for one message."""
+    lines = msg.splitlines()
+    fv = format_v2._evening_flags(lines, storm="")
+    score_line = safe_test_post._kld_evening_score_line(msg)
+    cover = kld_informative_cover.extract_kld_cover_facts(msg, post_type="evening")["weather"]
+    return {
+        "format_v2_storm_gust": fv["storm_gust"],
+        "format_v2_storm": fv["storm"],
+        "post_kld_overlay": post_kld._extract_storm_warning(msg) is not None,
+        "safe_test_post_storm": "штормов" in score_line.lower(),
+        "cover_storm_gust": cover["storm_gust"],
+        "cover_storm_badge": cover["storm_badge"],
+    }
+
+
+def kld_storm_gust_uses_gust_not_average_wind_across_all_layers() -> None:
+    # Cross-layer contract: storm classification keys on the actual gust
+    # ("порыв …"), never on average wind. format_v2._max_wind_ms previously
+    # matched both, so "ветер 16 м/с, порывы до 14 м/с" was wrongly a storm in
+    # format_v2 while the other three layers (real gust 14 < 15) said no.
+    def _assert_all(state: dict, storm: bool) -> None:
+        assert state["format_v2_storm_gust"] is storm, state
+        assert state["post_kld_overlay"] is storm, state
+        assert state["safe_test_post_storm"] is storm, state
+        assert state["cover_storm_gust"] is storm, state
+        assert state["cover_storm_badge"] is storm, state
+
+    # A. Average wind 16, no "порывы": not a storm anywhere.
+    _assert_all(_four_layer_storm_state(_wind_gust_evening(16)), storm=False)
+    # B. Average wind 16, gust 14 (< default 15): not a storm in any layer,
+    #    even though the average wind is high.
+    _assert_all(_four_layer_storm_state(_wind_gust_evening(16, 14)), storm=False)
+    # C. Average wind 8, gust 15 (== default 15): a storm in every layer.
+    _assert_all(_four_layer_storm_state(_wind_gust_evening(8, 15)), storm=True)
+
+    # B also keeps windy/water cues alive: a strong average wind still marks
+    # the day windy and can make the water guidance strict — it just isn't a
+    # storm. (max_wind comes through even when storm_gust is False.)
+    windy_flags = format_v2._evening_flags(_wind_gust_evening(16, 14).splitlines(), storm="")
+    assert windy_flags["wind"] is True
+    assert windy_flags["max_wind"] == 16.0
+    assert windy_flags["max_gust"] == 14.0
+    assert windy_flags["storm_gust"] is False
+
+
+def kld_storm_gust_threshold_override_uses_gust_across_all_layers() -> None:
+    # D/E. Raise the threshold to 16 and reload the env-bound layers; the cover
+    # reads the threshold live. 15 м/с gust is no longer a storm; 16 м/с is.
+    old_value = os.environ.get("STORM_GUST_MS")
+    try:
+        os.environ["STORM_GUST_MS"] = "16"
+        for mod in (weather_text, format_v2, safe_test_post, post_kld):
+            importlib.reload(mod)
+        assert weather_text.STORM_GUST_MS == 16.0
+
+        # D. gust 15 with a high average wind 16: below the raised threshold,
+        #    so no storm in any layer.
+        d = _four_layer_storm_state(_wind_gust_evening(16, 15))
+        assert d["format_v2_storm_gust"] is False, d
+        assert d["post_kld_overlay"] is False, d
+        assert d["safe_test_post_storm"] is False, d
+        assert d["cover_storm_gust"] is False, d
+        assert d["cover_storm_badge"] is False, d
+
+        # E. gust 16, weak average wind 8: at the raised threshold, a storm.
+        e = _four_layer_storm_state(_wind_gust_evening(8, 16))
+        assert e["format_v2_storm_gust"] is True, e
+        assert e["post_kld_overlay"] is True, e
+        assert e["safe_test_post_storm"] is True, e
+        assert e["cover_storm_gust"] is True, e
+        assert e["cover_storm_badge"] is True, e
+    finally:
+        if old_value is None:
+            os.environ.pop("STORM_GUST_MS", None)
+        else:
+            os.environ["STORM_GUST_MS"] = old_value
+        for mod in (weather_text, format_v2, safe_test_post, post_kld):
+            importlib.reload(mod)
+        assert weather_text.STORM_GUST_MS == (float(old_value) if old_value is not None else 15.0)
+
+
+def kld_evening_low_gust_hedged_storm_word_is_not_storm() -> None:
+    # Regression: "риск шторма невысок" at 9 м/с previously badged the day as
+    # storm because _has_explicit_storm_text / _extract_storm_warning only
+    # excluded the literal phrase "без шторма".
+    text = build_evening_format_v2("Калининградская область", LOW_GUST_STORM_WORD_EVENING)
+    assert "Штормовое предупреждение" not in text
+    assert "🧭 Главное завтра: неустойчивое погодное окно" not in text
+    assert _extract_storm_warning(LOW_GUST_STORM_WORD_EVENING) is None
+
+
+def kld_evening_gust14_below_threshold_is_not_storm_but_has_wind_nuance() -> None:
+    # Regression: 21.07 -> 22.07 case from the production export — 14 м/с is the
+    # strongest gust of the week (below STORM_GUST_MS=15) and the source text
+    # never says "шторм", so it must not get the storm badge, but it also must
+    # not be silently dropped to a plain forecast with no wind callout.
+    text = build_evening_format_v2("Калининградская область", GUST14_NO_STORM_WORD_EVENING)
+    assert "Штормовое предупреждение" not in text
+    assert "🧭 Главное завтра: неустойчивое погодное окно" not in text
+    assert "порывы" in text
+    assert _extract_storm_warning(GUST14_NO_STORM_WORD_EVENING) is None
+
+
 def kld_evening_astro_warning_does_not_trigger_image_storm() -> None:
     msg = "\n".join(
         [
@@ -475,6 +805,19 @@ def main() -> None:
         kld_evening_moderate_surf_keeps_cautious_positive,
         kld_evening_generic_warning_is_not_storm,
         kld_evening_rain_warning_is_not_storm,
+        kld_evening_safe_postprocess_does_not_promote_wind_nuance_to_storm,
+        kld_has_confirmed_storm_word_ignores_negation_from_a_different_line,
+        kld_has_confirmed_storm_word_all_lines_negated_is_false,
+        kld_has_confirmed_storm_word_confirmed_line_order_independent,
+        kld_storm_negation_handles_modifiers_and_clauses,
+        kld_storm_uncertainty_is_not_confirmation,
+        kld_storm_cancellation_is_scoped_to_the_warning,
+        kld_first_line_contains_is_clause_aware_morning_and_evening,
+        kld_storm_gust_ms_override_is_consistent_across_layers,
+        kld_storm_gust_uses_gust_not_average_wind_across_all_layers,
+        kld_storm_gust_threshold_override_uses_gust_across_all_layers,
+        kld_evening_low_gust_hedged_storm_word_is_not_storm,
+        kld_evening_gust14_below_threshold_is_not_storm_but_has_wind_nuance,
         kld_evening_astro_warning_does_not_trigger_image_storm,
         kld_evening_gust19_without_storm_word_is_storm,
         kld_evening_fully_populated_astro_preserves_voc,

--- a/tools/test_kld_image_first.py
+++ b/tools/test_kld_image_first.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -19,6 +20,7 @@ if str(ROOT) not in sys.path:
 from kld_image_first import FORMAT_V2_BEGIN, FORMAT_V2_END, run_image_first_publication  # noqa: E402
 from kld_informative_cover import (  # noqa: E402
     RENDERER_VERSION,
+    _factual_weather_truth,
     extract_kld_cover_facts,
     render_kld_informative_cover,
 )
@@ -393,23 +395,30 @@ def storm_and_precipitation_truth_are_independent() -> None:
     scenarios = {
         "dry_storm": (
             base + "Штормовое предупреждение: штормовой ветер, без осадков.\n",
-            {"explicit_storm": True, "actual_precipitation": False, "rain": False, "thunderstorm": False},
+            {"explicit_storm": True, "actual_precipitation": False, "rain": False,
+             "thunderstorm": False, "storm_gust": False, "storm_badge": True, "severe_weather": True},
         ),
         "negated_storm": (
             base + "Штормовых предупреждений нет; преимущественно сухо.\n",
-            {"explicit_storm": False, "actual_precipitation": False, "rain": False, "thunderstorm": False},
+            {"explicit_storm": False, "actual_precipitation": False, "rain": False,
+             "thunderstorm": False, "storm_gust": False, "storm_badge": False, "severe_weather": False},
         ),
         "negated_thunderstorm": (
             base + "Грозы не ожидаются; дождя не ожидается.\n",
-            {"explicit_storm": False, "actual_precipitation": False, "rain": False, "thunderstorm": False},
+            {"explicit_storm": False, "actual_precipitation": False, "rain": False,
+             "thunderstorm": False, "storm_gust": False, "storm_badge": False, "severe_weather": False},
         ),
         "thunderstorm_without_rain": (
+            # ⛈/гроза is NOT "шторм": explicit_storm and storm_badge stay False,
+            # thunderstorm is True, and the derived severe_weather umbrella is True.
             base + "⛈ Гроза, без осадков.\n",
-            {"explicit_storm": True, "actual_precipitation": False, "rain": False, "thunderstorm": True},
+            {"explicit_storm": False, "actual_precipitation": False, "rain": False,
+             "thunderstorm": True, "storm_gust": False, "storm_badge": False, "severe_weather": True},
         ),
         "rain_without_storm": (
             base.replace("☁️ облачно", "🌧 дождь"),
-            {"explicit_storm": False, "actual_precipitation": True, "rain": True, "thunderstorm": False},
+            {"explicit_storm": False, "actual_precipitation": True, "rain": True,
+             "thunderstorm": False, "storm_gust": False, "storm_badge": False, "severe_weather": False},
         ),
         "drizzle_without_rain": (
             base.replace("☁️ облачно", "морось"),
@@ -419,11 +428,15 @@ def storm_and_precipitation_truth_are_independent() -> None:
                 "rain": False,
                 "drizzle": True,
                 "thunderstorm": False,
+                "storm_gust": False,
+                "storm_badge": False,
+                "severe_weather": False,
             },
         ),
         "storm_and_rain": (
             base + "Штормовое предупреждение: сильный ветер.\n🌧 Дождь подтверждён.\n",
-            {"explicit_storm": True, "actual_precipitation": True, "rain": True, "thunderstorm": False},
+            {"explicit_storm": True, "actual_precipitation": True, "rain": True,
+             "thunderstorm": False, "storm_gust": False, "storm_badge": True, "severe_weather": True},
         ),
         "editorial_storm": (
             base
@@ -431,15 +444,22 @@ def storm_and_precipitation_truth_are_independent() -> None:
             + "⚠️ Главный нюанс: шторм у воды.\n"
             + "✅ План: дождь проверить утром.\n"
             + "🎯 Уверенность: гроза возможна.\n",
-            {"explicit_storm": False, "actual_precipitation": False, "rain": False, "thunderstorm": False},
+            {"explicit_storm": False, "actual_precipitation": False, "rain": False,
+             "thunderstorm": False, "storm_gust": False, "storm_badge": False, "severe_weather": False},
         ),
         "uncertain_rain": (
             base + "Вероятность дождя проверить утром.\n",
-            {"explicit_storm": False, "actual_precipitation": False, "rain": False, "thunderstorm": False},
+            {"explicit_storm": False, "actual_precipitation": False, "rain": False,
+             "thunderstorm": False, "storm_gust": False, "storm_badge": False, "severe_weather": False},
         ),
         "dry_severe_wind": (
+            # 17.5 м/с gusts are at/above the storm threshold, so this is a
+            # gust-driven storm even without the word "шторм": storm_gust and
+            # storm_badge and severe_weather are True, but explicit_storm and
+            # thunderstorm stay False (no lightning).
             base.replace("💨 5 м/с", "💨 9 м/с • порывы до 17.5 м/с") + "Преимущественно сухо.\n",
-            {"explicit_storm": False, "actual_precipitation": False, "rain": False, "thunderstorm": False},
+            {"explicit_storm": False, "actual_precipitation": False, "rain": False,
+             "thunderstorm": False, "storm_gust": True, "storm_badge": True, "severe_weather": True},
         ),
     }
 
@@ -464,6 +484,9 @@ def storm_and_precipitation_truth_are_independent() -> None:
                     "drizzle",
                     "snow",
                     "thunderstorm",
+                    "storm_gust",
+                    "storm_badge",
+                    "severe_weather",
                     "strong_wind",
                 )
             )
@@ -472,27 +495,39 @@ def storm_and_precipitation_truth_are_independent() -> None:
 
             rain_expected = expected["rain"]
             storm_expected = expected["explicit_storm"]
+            # Lightning graphics follow the thunderstorm flag, not explicit_storm:
+            # a storm-only day draws no lightning; a thunderstorm-only day does.
+            thunderstorm_expected = expected["thunderstorm"]
             assert metadata["rain_graphics"] is rain_expected, name
-            assert metadata["lightning_graphics"] is storm_expected, name
+            assert metadata["lightning_graphics"] is thunderstorm_expected, name
             assert bool(metadata["graphics"]["rain_lines"]) is rain_expected, name
-            assert bool(metadata["graphics"]["lightning_line"]) is storm_expected, name
+            assert bool(metadata["graphics"]["lightning_line"]) is thunderstorm_expected, name
 
             with Image.open(output) as image:
                 assert image.size == (1080, 1080)
                 embedded_weather = json.loads(image.info["weather_flags"])
                 embedded_graphics = json.loads(image.info["graphics"])
                 assert embedded_weather["explicit_storm"] is storm_expected, name
+                assert embedded_weather["thunderstorm"] is thunderstorm_expected, name
+                assert embedded_weather["storm_gust"] is expected["storm_gust"], name
+                assert embedded_weather["storm_badge"] is expected["storm_badge"], name
+                assert embedded_weather["severe_weather"] is expected["severe_weather"], name
                 assert embedded_weather["rain"] is rain_expected, name
+                assert image.info["explicit_storm"] == str(storm_expected).lower()
+                assert image.info["thunderstorm"] == str(thunderstorm_expected).lower()
+                assert image.info["storm_gust"] == str(expected["storm_gust"]).lower()
+                assert image.info["storm_badge"] == str(expected["storm_badge"]).lower()
+                assert image.info["severe_weather"] == str(expected["severe_weather"]).lower()
                 assert image.info["actual_precipitation"] == str(expected["actual_precipitation"]).lower()
                 assert image.info["rain_graphics"] == str(rain_expected).lower()
-                assert image.info["lightning_graphics"] == str(storm_expected).lower()
+                assert image.info["lightning_graphics"] == str(thunderstorm_expected).lower()
                 crop = image.crop((0, 590, 1080, 850))
                 pixel_source = getattr(crop, "get_flattened_data", crop.getdata)
                 pixels = list(pixel_source())
                 rain_pixels = pixels.count(tuple(embedded_graphics["rain_color"]))
                 lightning_pixels = pixels.count(tuple(embedded_graphics["lightning_color"]))
                 assert (rain_pixels > 0) is rain_expected, (name, rain_pixels)
-                assert (lightning_pixels > 0) is storm_expected, (name, lightning_pixels)
+                assert (lightning_pixels > 0) is thunderstorm_expected, (name, lightning_pixels)
 
             if name == "dry_storm":
                 assert weather["strong_wind"] is True
@@ -548,6 +583,13 @@ def drizzle_rain_and_snow_icons_keep_factual_intensity() -> None:
         ),
         "uncertain_snow": (
             base + "Снег возможен.\n",
+            {"actual_precipitation": False, "rain": False, "drizzle": False, "snow": False},
+        ),
+        "negated_snow_will_not_be": (
+            # Regression: "снега не будет" was not covered by the old negation
+            # list (only "снег не ожидается" / "без снега" / etc.), so a July
+            # rain-only day picked up a phantom "снег" fact from this phrasing.
+            base + "Снега не будет.\n",
             {"actual_precipitation": False, "rain": False, "drizzle": False, "snow": False},
         ),
     }
@@ -608,6 +650,338 @@ def drizzle_rain_and_snow_icons_keep_factual_intensity() -> None:
                 assert not metadata["graphics"]["rain_lines"]
             if name == "confirmed_snow":
                 assert metadata["facts"][0] == "СНЕГ МЕСТАМИ"
+
+
+def july_rain_day_with_hedged_snow_mention_has_no_snow_fact() -> None:
+    # Regression for the reported 21.07 (+17/+13 °C) cover: the text post said
+    # only "🌧 дождь" for the day, but an editorial line hedging that snow was
+    # not expected ("снега точно не будет") slipped past the old negation list
+    # and got rendered as "СНЕГ И ДОЖДЬ МЕСТАМИ" on the cover.
+    message = """<b>🌅 Калининградская область завтра (21.07.2026)</b>
+✨ VayboMeter завтра: 7.4/10 — тёплый летний день; днём дождь местами.
+🏙 Калининград — 17/13 °C • 🌧 дождь • 💨 5 м/с
+⚠️ Нюанс: несмотря на похолодание к ночи, снега точно не будет.
+#Калининград #погода
+"""
+    metadata = extract_kld_cover_facts(message, post_type="evening")
+    weather = metadata["weather"]
+    assert weather["snow"] is False, weather
+    assert weather["rain"] is True, weather
+    assert weather["precipitation_display"] == "rain", weather
+    assert metadata["facts"][0] == "ДОЖДЬ МЕСТАМИ", metadata["facts"]
+    assert not any("СНЕГ" in fact for fact in metadata["facts"]), metadata["facts"]
+
+
+def precipitation_negation_handles_modifiers_between_term_and_negation() -> None:
+    # Regression: the negation regex required the negation suffix to sit
+    # immediately after the term (single whitespace, no filler words), so
+    # hedged phrasings like "снега точно не будет" or "снега, скорее всего,
+    # не будет" slipped through as positive mentions. These lines are plain
+    # factual sentences (not "Нюанс:"-prefixed), so they exercise the negation
+    # regex itself rather than the editorial-line skip.
+    cases = {
+        "snow_certainly_not": ("Снега точно не будет.", {"snow": False, "actual_precipitation": False}),
+        "snow_probably_not": (
+            "Снега, скорее всего, не будет.",
+            {"snow": False, "actual_precipitation": False},
+        ),
+        "snow_probability_low": (
+            "Вероятность снега невысока.",
+            {"snow": False, "actual_precipitation": False},
+        ),
+        "rain_risk_minimal": ("Риск дождя минимален.", {"rain": False, "actual_precipitation": False}),
+        "snow_confirmed_evening": ("Снег будет вечером.", {"snow": True, "actual_precipitation": True}),
+    }
+    for name, (message, expected) in cases.items():
+        facts = _factual_weather_truth(message)
+        for flag, value in expected.items():
+            assert facts[flag] is value, (name, flag, facts)
+
+    # A negation in one clause must not cancel a genuine confirmation in a
+    # different clause on the same line.
+    two_clause = _factual_weather_truth("Снега не будет утром. Вечером ожидается снег.")
+    assert two_clause["snow"] is True, two_clause
+    assert two_clause["actual_precipitation"] is True, two_clause
+
+
+def mixed_precipitation_statements_keep_types_independent() -> None:
+    # Regression: _factual_weather_truth used a single global
+    # "precipitation_negated or precipitation_uncertain -> drop the whole
+    # clause" gate, so "Дождь будет, снега не будет." lost the real rain
+    # along with the negated snow. Each type (rain, drizzle, snow, generic
+    # precipitation) must now be evaluated independently: a negation of one
+    # type must not cancel evidence of a different type in the same clause.
+    cases = {
+        "rain_confirmed_snow_negated": (
+            "Дождь будет, снега не будет.",
+            {"rain": True, "snow": False, "actual_precipitation": True},
+        ),
+        "snow_confirmed_rain_negated": (
+            "Снег будет, дождя не ожидается.",
+            {"snow": True, "rain": False, "actual_precipitation": True},
+        ),
+        "drizzle_confirmed_rain_negated": (
+            "Морось будет, дождя не будет.",
+            {"drizzle": True, "rain": False, "actual_precipitation": True},
+        ),
+        "rain_negated_drizzle_uncertain": (
+            "Дождя не будет, возможна морось.",
+            {"rain": False, "drizzle": False, "actual_precipitation": False},
+        ),
+        "rain_negated_drizzle_confirmed": (
+            "Дождя не будет, морось ожидается.",
+            {"rain": False, "drizzle": True, "actual_precipitation": True},
+        ),
+        "snow_negated_morning_confirmed_evening": (
+            "Снега не будет утром; вечером ожидается снег.",
+            {"snow": True, "actual_precipitation": True},
+        ),
+    }
+    for name, (message, expected) in cases.items():
+        facts = _factual_weather_truth(message)
+        for flag, value in expected.items():
+            assert facts[flag] is value, (name, flag, facts)
+
+
+def precipitation_uncertainty_binds_to_nearest_type() -> None:
+    # Regression: an uncertainty cue preceding a type ("возможна морось",
+    # "Дождь возможен") used to reach across a comma to a *following* type,
+    # so "Дождь возможен, снег ожидается." wrongly marked snow uncertain too.
+    # The cue must bind to the nearest type only.
+    cases = {
+        "rain_uncertain_snow_confirmed": (
+            "Дождь возможен, снег ожидается.",
+            {"rain": False, "snow": True, "actual_precipitation": True},
+        ),
+        "snow_uncertain_rain_confirmed": (
+            "Снег возможен, дождь ожидается.",
+            {"snow": False, "rain": True, "actual_precipitation": True},
+        ),
+        "drizzle_uncertain_rain_confirmed": (
+            "Морось возможна, дождь ожидается.",
+            {"drizzle": False, "rain": True, "actual_precipitation": True},
+        ),
+        "rain_uncertain_drizzle_confirmed": (
+            "Дождь возможен, морось ожидается.",
+            {"rain": False, "drizzle": True, "actual_precipitation": True},
+        ),
+    }
+    for name, (message, expected) in cases.items():
+        facts = _factual_weather_truth(message)
+        for flag, value in expected.items():
+            assert facts[flag] is value, (name, flag, facts)
+
+
+def precipitation_active_exclusion_verb_is_not_negation() -> None:
+    # Regression: a bare "исключ\w*" treated "Снег исключил движение." (snow
+    # is the actor) as a negation. Only the passive participle "исключён/
+    # исключена" (the fact was removed from the forecast) denies precipitation.
+    cases = {
+        "rain_actor_excluded_walk": ("Дождь исключил прогулку.", {"rain": True, "actual_precipitation": True}),
+        "snow_actor_excluded_traffic": ("Снег исключил движение.", {"snow": True, "actual_precipitation": True}),
+        "snow_fact_excluded_from_forecast": (
+            "Снег исключён из прогноза.",
+            {"snow": False, "actual_precipitation": False},
+        ),
+    }
+    for name, (message, expected) in cases.items():
+        facts = _factual_weather_truth(message)
+        for flag, value in expected.items():
+            assert facts[flag] is value, (name, flag, facts)
+
+
+def storm_and_thunderstorm_are_independent_per_clause() -> None:
+    # explicit_storm means a confirmed "шторм" word ONLY; thunderstorm means a
+    # confirmed "гроза"/⛈ ONLY. Neither flag raises the other — a confirmed
+    # thunderstorm no longer sets explicit_storm, and a confirmed storm no
+    # longer sets thunderstorm. The umbrella "either severe phenomenon" case
+    # is the separate derived severe_weather flag.
+    cases = {
+        # 1
+        "storm_negated_thunderstorm_confirmed": (
+            "Шторма не будет, гроза ожидается.",
+            {"explicit_storm": False, "thunderstorm": True, "severe_weather": True},
+        ),
+        # 2
+        "thunderstorm_negated_storm_confirmed": (
+            "Грозы не будет, шторм ожидается.",
+            {"explicit_storm": True, "thunderstorm": False, "severe_weather": True},
+        ),
+        # 3
+        "storm_uncertain_thunderstorm_confirmed": (
+            "Шторм возможен, гроза ожидается.",
+            {"explicit_storm": False, "thunderstorm": True, "severe_weather": True},
+        ),
+        # 4
+        "storm_confirmed_thunderstorm_uncertain": (
+            "Шторм ожидается, гроза возможна.",
+            {"explicit_storm": True, "thunderstorm": False, "severe_weather": True},
+        ),
+        # 5
+        "storm_and_thunderstorm_both_confirmed": (
+            "Шторм и гроза ожидаются.",
+            {"explicit_storm": True, "thunderstorm": True, "severe_weather": True},
+        ),
+    }
+    for name, (message, expected) in cases.items():
+        facts = _factual_weather_truth(message)
+        for flag, value in expected.items():
+            assert facts[flag] is value, (name, flag, facts)
+
+
+def storm_and_thunderstorm_flags_drive_graphics_independently() -> None:
+    # End-to-end: metadata stores explicit_storm and thunderstorm as separate
+    # booleans, and neither raises the other's graphic — a storm-only day draws
+    # no lightning, a thunderstorm-only day does.
+    from PIL import Image
+
+    base = """<b>🌅 Калининградская область завтра (21.07.2026)</b>
+🏙 Калининград — 20/14 °C • ☁️ облачно • 💨 5 м/с
+#Калининград #погода
+"""
+    scenarios = {
+        "storm_only": (
+            base + "Штормовое предупреждение: штормовой ветер, без осадков.\n",
+            {"explicit_storm": True, "thunderstorm": False, "severe_weather": True},
+        ),
+        "thunderstorm_only": (
+            base + "⛈ Гроза, без осадков.\n",
+            {"explicit_storm": False, "thunderstorm": True, "severe_weather": True},
+        ),
+    }
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        for name, (message, expected) in scenarios.items():
+            output = root / f"{name}.png"
+            metadata = render_kld_informative_cover(message, post_type="evening", output_path=output)
+            weather = metadata["weather"]
+            assert weather["explicit_storm"] is expected["explicit_storm"], name
+            assert weather["thunderstorm"] is expected["thunderstorm"], name
+            assert weather["severe_weather"] is expected["severe_weather"], name
+            # Lightning is present iff thunderstorm, regardless of explicit_storm.
+            assert metadata["lightning_graphics"] is expected["thunderstorm"], name
+            with Image.open(output) as image:
+                embedded = json.loads(image.info["weather_flags"])
+                assert embedded["explicit_storm"] is expected["explicit_storm"], name
+                assert embedded["thunderstorm"] is expected["thunderstorm"], name
+                assert embedded["severe_weather"] is expected["severe_weather"], name
+                lightning_pixels = image.crop((0, 590, 1080, 850)).getdata()
+                lc = tuple(json.loads(image.info["graphics"])["lightning_color"])
+                assert (list(lightning_pixels).count(lc) > 0) is expected["thunderstorm"], name
+
+
+def storm_badge_uses_word_or_gust_threshold_not_strong_wind() -> None:
+    # The "ШТОРМОВОЕ ПРЕДУПРЕЖДЕНИЕ" cover badge must fire on a confirmed storm
+    # word OR a gust at/above STORM_GUST_MS, matching format_v2 /
+    # safe_test_post / post_kld. It must NOT rely on strong_wind, which starts
+    # at 12 м/с — below the storm threshold. thunderstorm drives lightning
+    # only, never the storm badge.
+    import importlib
+
+    import weather_text
+    import kld_informative_cover
+
+    def _wind_message(gust_ms: float) -> str:
+        return (
+            "<b>🌅 Калининградская область завтра (21.07.2026)</b>\n"
+            f"🏙 Калининград — 20/14 °C • ☁️ облачно • 💨 8 м/с • порывы до {gust_ms} м/с\n"
+            "#Калининград #погода\n"
+        )
+
+    def _facts(message: str) -> dict:
+        return kld_informative_cover.extract_kld_cover_facts(message, post_type="evening")
+
+    def _has_storm_badge(message: str) -> bool:
+        return "ШТОРМОВОЕ ПРЕДУПРЕЖДЕНИЕ" in _facts(message)["facts"]
+
+    def _lightning(message: str) -> bool:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            meta = render_kld_informative_cover(
+                message, post_type="evening", output_path=Path(tmp) / "c.png"
+            )
+            return bool(meta["lightning_graphics"])
+
+    # A. 14 м/с, no storm word: not a storm at all, but strong_wind may be True.
+    a = _facts(_wind_message(14))["weather"]
+    assert a["explicit_storm"] is False
+    assert a["thunderstorm"] is False
+    assert a["storm_gust"] is False
+    assert a["storm_badge"] is False
+    assert a["severe_weather"] is False
+    assert a["strong_wind"] is True  # 14 >= 12, but below the storm threshold
+    assert _has_storm_badge(_wind_message(14)) is False
+    assert _lightning(_wind_message(14)) is False
+
+    # B. 15 м/с at the default threshold of 15: gust-driven storm, no lightning.
+    b = _facts(_wind_message(15))["weather"]
+    assert b["explicit_storm"] is False
+    assert b["thunderstorm"] is False
+    assert b["storm_gust"] is True
+    assert b["storm_badge"] is True
+    assert b["severe_weather"] is True
+    assert _has_storm_badge(_wind_message(15)) is True
+    assert _lightning(_wind_message(15)) is False
+
+    # C/D. Raise the threshold to 16 and reload the shared module: 15 м/с is no
+    # longer a storm, 16 м/с is. The cover reads the threshold live from
+    # weather_text, so no reload of kld_informative_cover is required.
+    old_value = os.environ.get("STORM_GUST_MS")
+    try:
+        os.environ["STORM_GUST_MS"] = "16"
+        importlib.reload(weather_text)
+        assert weather_text.STORM_GUST_MS == 16.0
+
+        c = _facts(_wind_message(15))["weather"]
+        assert c["storm_gust"] is False
+        assert c["storm_badge"] is False
+        assert _has_storm_badge(_wind_message(15)) is False
+
+        d = _facts(_wind_message(16))["weather"]
+        assert d["storm_gust"] is True
+        assert d["storm_badge"] is True
+        assert _has_storm_badge(_wind_message(16)) is True
+    finally:
+        if old_value is None:
+            os.environ.pop("STORM_GUST_MS", None)
+        else:
+            os.environ["STORM_GUST_MS"] = old_value
+        importlib.reload(weather_text)
+        assert weather_text.STORM_GUST_MS == (float(old_value) if old_value is not None else 15.0)
+
+    # E. Thunderstorm, weak wind: thunderstorm + severe_weather + lightning, but
+    # no storm word and no storm badge.
+    thunder_msg = (
+        "<b>🌅 Калининградская область завтра (21.07.2026)</b>\n"
+        "🏙 Калининград — 20/14 °C • 💨 4 м/с\n"
+        "Гроза ожидается.\n"
+        "#Калининград #погода\n"
+    )
+    e = _facts(thunder_msg)["weather"]
+    assert e["explicit_storm"] is False
+    assert e["thunderstorm"] is True
+    assert e["storm_gust"] is False
+    assert e["storm_badge"] is False
+    assert e["severe_weather"] is True
+    assert _has_storm_badge(thunder_msg) is False
+    assert _lightning(thunder_msg) is True
+
+    # F. Storm word, weak wind, no thunderstorm: storm badge, no lightning.
+    storm_msg = (
+        "<b>🌅 Калининградская область завтра (21.07.2026)</b>\n"
+        "🏙 Калининград — 20/14 °C • 💨 4 м/с\n"
+        "Шторм ожидается.\n"
+        "#Калининград #погода\n"
+    )
+    f = _facts(storm_msg)["weather"]
+    assert f["explicit_storm"] is True
+    assert f["thunderstorm"] is False
+    assert f["storm_gust"] is False
+    assert f["storm_badge"] is True
+    assert f["severe_weather"] is True
+    assert _has_storm_badge(storm_msg) is True
+    assert _lightning(storm_msg) is False
 
 
 def mixed_regional_precipitation_keeps_text_and_graphics_aligned() -> None:
@@ -712,6 +1086,14 @@ TESTS = [
     local_cover_is_png_1080_and_weather_factual,
     storm_and_precipitation_truth_are_independent,
     drizzle_rain_and_snow_icons_keep_factual_intensity,
+    july_rain_day_with_hedged_snow_mention_has_no_snow_fact,
+    precipitation_negation_handles_modifiers_between_term_and_negation,
+    mixed_precipitation_statements_keep_types_independent,
+    precipitation_uncertainty_binds_to_nearest_type,
+    precipitation_active_exclusion_verb_is_not_negation,
+    storm_and_thunderstorm_are_independent_per_clause,
+    storm_and_thunderstorm_flags_drive_graphics_independently,
+    storm_badge_uses_word_or_gust_threshold_not_strong_wind,
     mixed_regional_precipitation_keeps_text_and_graphics_aligned,
 ]
 

--- a/weather_text.py
+++ b/weather_text.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Shared, dependency-free weather-text classification for KLD posts.
+
+format_v2.py, safe_test_post.py, post_kld.py and kld_informative_cover.py each
+grew their own "шторм" word/negation regex and their own literal gust
+threshold (15), and the four copies drifted out of sync with each other and
+with STORM_GUST_MS. This module is the single contract for both, so all
+four import from here instead of maintaining separate regexes. It has no
+dependencies beyond the standard library, so importing it does not pull in
+any of post_common's heavier runtime requirements.
+"""
+from __future__ import annotations
+
+import os
+import re
+
+STORM_GUST_MS = float(os.getenv("STORM_GUST_MS", "15"))
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+# Single wind/gust parser shared by all layers, so a gust threshold is applied
+# to the same value everywhere.
+#
+# A GUST is only a "порыв …" construction ("порывы до 15 м/с", "порыв 15 м/с",
+# "порывы 15 м/с"). Plain wind ("ветер 15 м/с", "💨 15 м/с", "15 м/с") is NOT a
+# gust — this is the whole point of the split: storm classification keys on the
+# gust, never on average wind. WIND is any "N м/с" number (average or gust),
+# used for the softer windy / water-caution / comfort cues.
+_GUST_MS_RE = re.compile(r"порыв\w*\s*(?:до\s*)?(-?\d+(?:[.,]\d+)?)\s*м\s*/?\s*с", re.IGNORECASE)
+_WIND_MS_RE = re.compile(r"(-?\d+(?:[.,]\d+)?)\s*м\s*/?\s*с", re.IGNORECASE)
+
+
+def _max_ms(pattern: re.Pattern[str], text: str) -> float | None:
+    values: list[float] = []
+    for raw in pattern.findall(str(text or "")):
+        try:
+            values.append(float(raw.replace(",", ".")))
+        except (TypeError, ValueError):
+            continue
+    return max(values) if values else None
+
+
+def extract_max_gust_ms(text: str) -> float | None:
+    """Max gust in m/s, counting ONLY explicit "порыв …" constructions.
+
+    Plain average wind ("ветер 16 м/с", "💨 16 м/с", "16 м/с") returns None
+    here — it is never a gust, so it never drives the storm threshold."""
+    return _max_ms(_GUST_MS_RE, text)
+
+
+def extract_max_wind_ms(text: str) -> float | None:
+    """Max wind in m/s over any "N м/с" number (average or gust), for the
+    softer windy / water-caution / comfort cues — not for storm classification."""
+    return _max_ms(_WIND_MS_RE, text)
+
+# Sentence-ending punctuation, or a comma followed by a contrastive
+# conjunction ("но"/"а") joining two independent weather statements, e.g.
+# "Риск шторма невысок, но штормовое предупреждение действует у моря."
+_CLAUSE_SPLIT_RE = re.compile(r"(?<=[.!?;])\s+|,\s+(?:но|а)\s+")
+
+
+def split_clauses(line: str) -> list[str]:
+    """Split a line into independent clauses so a negation in one clause
+    cannot be mistaken for negating a different clause."""
+    return [clause.strip() for clause in _CLAUSE_SPLIT_RE.split(str(line or "")) if clause.strip()]
+
+
+STORM_WORD_RE = re.compile(r"шторм\w*", re.IGNORECASE)
+
+# Bounded gap (<=40 chars) between the storm term and its negation/hedge, so
+# modifiers ("Шторма точно не будет.", "Риск шторма в другой части области
+# невысок.") are still recognized. Two directions, like the precipitation
+# gaps in kld_informative_cover:
+#  - AFTER (term then cue, "шторм ... не будет"): may cross commas so
+#    parenthetical modifiers work ("шторма, скорее всего, не будет").
+#  - BEFORE (cue then term, "возможен шторм", "риск шторма"): must NOT cross a
+#    comma, so a cue that belongs to a preceding statement does not bind the
+#    storm ("Гроза возможна, шторм ожидается." keeps the storm confirmed).
+# Both gaps also forbid another "шторм" and the sibling severe type "гроз", so
+# a cue/negation cannot leap over an unrelated, separately-classified mention
+# ("Шторм ожидается, гроза возможна." must keep the storm confirmed — the
+# "возможна" belongs to the thunderstorm, on the far side of "гроза").
+_STORM_GAP_AFTER = r"(?:(?!шторм\w*|гроз\w*)[^.!?\n]){0,40}?"
+_STORM_GAP_BEFORE = r"(?:(?!шторм\w*|гроз\w*)[^.!?\n,]){0,40}?"
+
+# A weather warning is cancelled only when the *warning* is the subject of a
+# cancellation verb ("предупреждение отменено/снято/не действует"). This is
+# deliberately NOT a bare "отмен\w*"/"исключ\w*": those also match the storm
+# being the *actor* ("Шторм отменил паромные рейсы.", "Из-за шторма отменены
+# рейсы."), which confirm a storm rather than deny one. Passive-fact removal
+# ("исключён из прогноза") is handled by the исключ(ён|ена…) participle form,
+# which does not match the active verb "исключил".
+_WARNING_CANCELLED = r"предупрежден\w*{gap}\b(?:отмен(?:ён\w*|ен[аоы]\w*)|снят\w*|не\s+действ\w*)"
+STORM_NEGATION_RE = re.compile(
+    r"штормов\w*\s+предупрежден\w*\s+нет|"
+    + _WARNING_CANCELLED.format(gap=_STORM_GAP_AFTER)
+    + r"|"
+    rf"шторм\w*{_STORM_GAP_AFTER}\b(?:не\s+(?:ожида\w*|будет|прогнозир\w*|предвид\w*|подтвержд\w*)|"
+    r"маловероят\w*|исключ(?:ён\w*|ен[аоы]\w*))|"
+    r"без\s+шторм\w*|"
+    rf"(?:риск|вероятност\w*){_STORM_GAP_BEFORE}\bшторм\w*{_STORM_GAP_AFTER}\b(?:низк\w*|невысок\w*|минимал\w*|отсутств\w*)",
+    re.IGNORECASE,
+)
+
+# A storm mention is not a confirmed fact when it is hedged: possibility
+# ("Шторм возможен.", "Возможен шторм."), probability ("Вероятность шторма
+# 30%."), a persisting-but-unrealized risk ("Риск шторма сохраняется."), a
+# "check/clarify later" note ("Шторм следует уточнить утром."), or an explicit
+# "not ruled out" ("Шторм не исключён.").
+_STORM_UNCERTAIN_CUE = r"провер\w*|уточн\w*|возмож\w*|вероятн\w*|не\s+исключ\w*|сохраня\w*"
+STORM_UNCERTAIN_RE = re.compile(
+    rf"шторм\w*{_STORM_GAP_AFTER}\b(?:{_STORM_UNCERTAIN_CUE})|"
+    rf"(?:возмож\w*|вероятност\w*|риск){_STORM_GAP_BEFORE}\bшторм\w*",
+    re.IGNORECASE,
+)
+
+EDITORIAL_LINE_RE = re.compile(
+    r"^\W*(?:главный\s+нюанс|нюанс|vaybometer|план|рекомендации|уверенность)"
+    r"(?:\s+[^:]{1,32})?\s*:",
+    re.IGNORECASE,
+)
+
+
+def clause_has_confirmed_storm(clause: str) -> bool:
+    """True only if this single clause has a "шторм" mention that is neither
+    negated (STORM_NEGATION_RE) nor merely hedged (STORM_UNCERTAIN_RE)."""
+    low = clause.lower()
+    return (
+        bool(STORM_WORD_RE.search(low))
+        and not STORM_NEGATION_RE.search(low)
+        and not STORM_UNCERTAIN_RE.search(low)
+    )
+
+
+def has_confirmed_storm_word(text: str) -> bool:
+    """True if any non-editorial clause in the text has a non-negated
+    "шторм" mention.
+
+    Checked per clause (line, then sentence/contrast split): a negation in
+    one clause ("риск шторма в другой части области невысок") must not
+    cancel a genuine confirmation in a different clause or line ("Штормовое
+    предупреждение: порывы до 18 м/с.").
+    """
+    for raw_line in str(text or "").splitlines():
+        line = _HTML_TAG_RE.sub("", raw_line).strip()
+        if not line or EDITORIAL_LINE_RE.match(line.lower()):
+            continue
+        for clause in split_clauses(line):
+            if clause_has_confirmed_storm(clause):
+                return True
+    return False
+
+
+__all__ = [
+    "STORM_GUST_MS",
+    "extract_max_gust_ms",
+    "extract_max_wind_ms",
+    "split_clauses",
+    "STORM_WORD_RE",
+    "STORM_NEGATION_RE",
+    "STORM_UNCERTAIN_RE",
+    "EDITORIAL_LINE_RE",
+    "clause_has_confirmed_storm",
+    "has_confirmed_storm_word",
+]


### PR DESCRIPTION
## What changed

- Added one shared `weather_text.py` contract for storm wording, gust parsing, negation handling, and the `STORM_GUST_MS` threshold across `format_v2.py`, `safe_test_post.py`, `post_kld.py`, and `kld_informative_cover.py`.
- Separated average wind from explicit gust values: only constructions containing `порыв…` can trigger `storm_gust`.
- Kept `explicit_storm` and `thunderstorm` independent; lightning now follows only confirmed thunderstorm evidence.
- Defined `storm_badge = explicit_storm or storm_gust` and `severe_weather = explicit_storm or thunderstorm or storm_gust`.
- Fixed clause-aware precipitation negations so denying one precipitation type does not cancel another confirmed type.
- Preserved nonblocking text publication when image generation or delivery fails.

## Root cause

Four layers had drifted into separate storm/gust parsers and thresholds. Some paths treated ordinary wind values or weak warning wording as storm evidence, which produced false storm badges for forecasts such as gusts of 14 m/s when the configured threshold was 15 m/s.

## Validation

Full offline suite: **209/209 checks passed across 14 scripts**.

Key boundary checks:
- ordinary wind is not a gust;
- gust 14 m/s at threshold 15 is not `storm_gust`;
- gust 15 m/s at threshold 15 is `storm_gust`;
- threshold overrides are consistent across all four layers;
- storm/thunderstorm flags and lightning behavior are independent;
- precipitation negations are clause/type aware;
- image failure does not block text publication.

Additional gates:
- `python -m compileall -q .` passed;
- sequential `py_compile` passed for 52 tracked Python files;
- 10 workflow YAML files parsed successfully;
- `git diff --check` passed;
- diff contains only the seven intended code/test files and no Schumann/Safecast data, workflows, binaries, caches, temporary files, or secrets.