### PR TITLE
fix: harden KLD image fallback pipeline

### DIFF
--- a/image_prompt_kld.py
+++ b/image_prompt_kld.py
@@ -342,6 +342,8 @@ KLD_SCENE_FAMILIES: tuple[str, ...] = (
     "quiet_lagoon_coast",
     "wet_seaside_promenade",
     "elevated_baltic_overlook",
+    "kaliningrad_urban_coastal_view",
+    "rainy_coastal_road",
 )
 
 _KLD_SCENE_TEXT = {
@@ -355,6 +357,8 @@ _KLD_SCENE_TEXT = {
     "quiet_lagoon_coast": "quiet lagoon-like Baltic coast with reeds, low shore and subdued northern atmosphere",
     "wet_seaside_promenade": "wet seaside promenade after rain with dry-to-damp stone texture and realistic reflections",
     "elevated_baltic_overlook": "elevated Baltic overlook from a dune or cliff path, wide sea and coastline below",
+    "kaliningrad_urban_coastal_view": "urban Baltic coastal edge with modest Kaliningrad-region architecture, promenade and sea horizon",
+    "rainy_coastal_road": "rain-darkened coastal road near dunes and pines, with the Baltic shoreline visible beyond",
 }
 
 KLD_COMPOSITIONS: tuple[str, ...] = (
@@ -768,15 +772,49 @@ def _rain_cloud_fog_category(ctx: Any) -> str:
     return "clear_or_mixed"
 
 
-def _scene_index(date_key: str, post_type: str, weather_main: str, variation_attempt: int) -> int:
+def _scene_catalog(weather_main: str) -> tuple[str, ...]:
+    if weather_main == "storm":
+        return (
+            "stormy_open_baltic",
+            "baltiysk_breakwater",
+            "svetlogorsk_cliff_coast",
+            "wet_seaside_promenade",
+            "rainy_coastal_road",
+            "elevated_baltic_overlook",
+        )
+    if weather_main in {"rain", "drizzle"}:
+        return (
+            "wet_seaside_promenade",
+            "rainy_coastal_road",
+            "zelenogradsk_promenade",
+            "baltiysk_breakwater",
+            "svetlogorsk_cliff_coast",
+            "pine_forest_sea_path",
+            "kaliningrad_urban_coastal_view",
+            "curonian_spit_dunes",
+            "quiet_lagoon_coast",
+            "elevated_baltic_overlook",
+        )
+    return tuple(
+        scene
+        for scene in KLD_SCENE_FAMILIES
+        if scene not in {"stormy_open_baltic", "wet_seaside_promenade", "rainy_coastal_road"}
+    )
+
+
+def _scene_index(
+    date_key: str,
+    post_type: str,
+    weather_main: str,
+    variation_attempt: int,
+    *,
+    count: int,
+) -> int:
     base_date = _date_from_key(date_key)
     ordinal = base_date.toordinal() if base_date else _stable_index(date_key, "scene_ordinal", 10_000)
     offset = 5 if (post_type or "").strip().lower() == "evening" else 0
-    if weather_main == "storm":
-        offset += KLD_SCENE_FAMILIES.index("stormy_open_baltic")
-    elif weather_main in {"rain", "drizzle"}:
-        offset += KLD_SCENE_FAMILIES.index("wet_seaside_promenade")
-    return (ordinal * 3 + offset + int(variation_attempt or 0)) % len(KLD_SCENE_FAMILIES)
+    step = 5 if count % 5 else 3
+    return (ordinal * step + offset + int(variation_attempt or 0)) % count
 
 
 def kld_scene_metadata(
@@ -788,7 +826,16 @@ def kld_scene_metadata(
     variation_attempt: int = 0,
 ) -> dict[str, str]:
     weather = _weather_scenario(ctx)
-    scene_family = KLD_SCENE_FAMILIES[_scene_index(date_key, post_type, weather, variation_attempt)]
+    scene_catalog = _scene_catalog(weather)
+    scene_family = scene_catalog[
+        _scene_index(
+            date_key,
+            post_type,
+            weather,
+            variation_attempt,
+            count=len(scene_catalog),
+        )
+    ]
     composition_idx = (
         (_date_from_key(date_key).toordinal() if _date_from_key(date_key) else 0)
         + _stable_index(weather, "kld_composition_offset", len(KLD_COMPOSITIONS))

--- a/imagegen.py
+++ b/imagegen.py
@@ -23,14 +23,19 @@ Extra (new, optional):
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import io
+import ipaddress
+import json
 import logging
 import os
+import socket
 import time
 from pathlib import Path
 from typing import Optional, Tuple, Any
-from urllib.parse import quote
+from urllib.error import HTTPError
+from urllib.parse import quote, urljoin, urlparse
 import urllib.request
 
 log = logging.getLogger(__name__)
@@ -45,6 +50,47 @@ HTTP_RETRIES = int(os.getenv("IMG_HTTP_RETRIES", "3"))
 HTTP_BACKOFF = float(os.getenv("IMG_HTTP_BACKOFF", "1.6"))
 
 DEFAULT_DIR = Path(os.getenv("IMG_OUT_DIR", ".cache/images"))
+HORDE_BASE_URL = "https://stablehorde.net/api/v2"
+
+_LAST_GENERATION_DIAGNOSTICS: dict[str, dict[str, Any]] = {}
+
+
+class ImageGenerationError(RuntimeError):
+    """Provider failure with structured, secret-free HTTP attempt diagnostics."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        backend: str,
+        reason: str,
+        attempts: list[dict[str, Any]] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.backend = backend
+        self.reason = reason
+        self.attempts = list(attempts or [])
+
+
+def _set_generation_diagnostics(backend: str, payload: dict[str, Any]) -> None:
+    _LAST_GENERATION_DIAGNOSTICS[backend] = dict(payload)
+
+
+def get_generation_diagnostics(backend: str) -> dict[str, Any]:
+    return dict(_LAST_GENERATION_DIAGNOSTICS.get(str(backend), {}))
+
+
+def stable_horde_enabled() -> bool:
+    return os.getenv("KLD_STABLE_HORDE_ENABLED", "1").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _exception_attempt(attempt: int, exc: Exception) -> dict[str, Any]:
+    return {
+        "attempt": attempt,
+        "exception_type": type(exc).__name__,
+        "http_status": int(exc.code) if isinstance(exc, HTTPError) else None,
+        "message": " ".join(str(exc).split())[:300],
+    }
 
 
 def _sha_seed(text: str) -> int:
@@ -151,6 +197,26 @@ def _to_jpeg_bytes(data: bytes) -> Tuple[bytes, str]:
         return data, "original"
 
 
+def _validate_download_payload(data: bytes, content_type: Optional[str]) -> None:
+    if _sniff_ext(data, content_type) is None:
+        raise ValueError("imagegen: response is not a supported image")
+    try:
+        from PIL import Image
+
+        with Image.open(io.BytesIO(data)) as image:
+            image.load()
+            if image.width < 256 or image.height < 256:
+                raise ValueError(
+                    f"imagegen: image dimensions too small ({image.width}x{image.height})"
+                )
+    except ImportError:
+        return
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise ValueError("imagegen: response failed image validation") from exc
+
+
 def _http_get(url: str, *, timeout: float) -> Tuple[bytes, Optional[str]]:
     req = urllib.request.Request(
         url,
@@ -172,6 +238,7 @@ def download_image_to_file(
     *,
     timeout: float = HTTP_TIMEOUT,
     retries: int = HTTP_RETRIES,
+    backend: str = "pollinations",
 ) -> str:
     """
     Download image by URL and save to disk. Returns the final saved filepath.
@@ -186,6 +253,7 @@ def download_image_to_file(
     _ensure_parent(out)
 
     last_err: Optional[Exception] = None
+    attempts: list[dict[str, Any]] = []
     retries = max(1, int(retries))
 
     for attempt in range(1, retries + 1):
@@ -195,6 +263,7 @@ def download_image_to_file(
             if not data or len(data) < 128:
                 raise ValueError(f"imagegen: response too small ({len(data)} bytes)")
 
+            _validate_download_payload(data, ctype)
             jpg_bytes, mode = _to_jpeg_bytes(data)
 
             if mode == "jpeg":
@@ -208,11 +277,30 @@ def download_image_to_file(
             _ensure_parent(out_final)
             out_final.write_bytes(payload)
 
+            attempts.append(
+                {
+                    "attempt": attempt,
+                    "exception_type": "",
+                    "http_status": 200,
+                    "message": "",
+                    "payload_bytes": len(payload),
+                }
+            )
+            _set_generation_diagnostics(
+                backend,
+                {
+                    "backend": backend,
+                    "http_attempt_count": len(attempts),
+                    "attempts": attempts,
+                    "result": "success",
+                },
+            )
             log.info("imagegen: saved image -> %s (attempt=%d, mode=%s)", out_final, attempt, mode)
             return str(out_final)
 
         except Exception as e:
             last_err = e
+            attempts.append(_exception_attempt(attempt, e))
             if attempt < retries:
                 sleep_s = (HTTP_BACKOFF ** (attempt - 1))
                 log.warning(
@@ -224,7 +312,25 @@ def download_image_to_file(
                 )
                 time.sleep(sleep_s)
 
-    raise RuntimeError(f"imagegen: failed to download image after {retries} tries: {last_err}")
+    reason = (
+        "invalid_image"
+        if isinstance(last_err, ValueError) and "imagegen:" in str(last_err)
+        else "provider_failure"
+    )
+    diagnostics = {
+        "backend": backend,
+        "http_attempt_count": len(attempts),
+        "attempts": attempts,
+        "result": "failed",
+        "reason": reason,
+    }
+    _set_generation_diagnostics(backend, diagnostics)
+    raise ImageGenerationError(
+        f"imagegen: failed to download image after {retries} tries: {last_err}",
+        backend=backend,
+        reason=reason,
+        attempts=attempts,
+    )
 
 
 def _extract_args(args: tuple[Any, ...], kwargs: dict[str, Any]) -> tuple[str, Optional[str], Optional[str], dict[str, Any]]:
@@ -322,6 +428,318 @@ def generate_kld_evening_image(*args, **kwargs) -> str:
     )
     log.info("imagegen: Pollinations URL built (len=%d)", len(url))
     return download_image_to_file(url, out_path)
+
+
+def _horde_json_request(
+    url: str,
+    *,
+    method: str,
+    headers: dict[str, str],
+    attempts: list[dict[str, Any]],
+    stage: str,
+    timeout: float,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    body = json.dumps(payload).encode("utf-8") if payload is not None else None
+    request = urllib.request.Request(url, data=body, headers=headers, method=method)
+    attempt_number = len(attempts) + 1
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read()
+            status = int(getattr(response, "status", 200) or 200)
+            attempts.append(
+                {
+                    "attempt": attempt_number,
+                    "stage": stage,
+                    "exception_type": "",
+                    "http_status": status,
+                    "message": "",
+                    "payload_bytes": len(raw),
+                }
+            )
+    except Exception as exc:
+        item = _exception_attempt(attempt_number, exc)
+        item["stage"] = stage
+        attempts.append(item)
+        raise
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except Exception as exc:
+        attempts[-1]["exception_type"] = type(exc).__name__
+        attempts[-1]["message"] = "invalid JSON response"
+        raise ValueError(f"Stable Horde {stage} returned invalid JSON") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"Stable Horde {stage} returned a non-object response")
+    return data
+
+
+def _public_horde_image_url(value: str) -> bool:
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname or parsed.username or parsed.password:
+        return False
+    hostname = parsed.hostname.lower()
+    if hostname == "localhost" or hostname.endswith(".localhost"):
+        return False
+    try:
+        addresses = [ipaddress.ip_address(hostname)]
+    except ValueError:
+        try:
+            addresses = [
+                ipaddress.ip_address(item[4][0])
+                for item in socket.getaddrinfo(hostname, parsed.port or 443, type=socket.SOCK_STREAM)
+            ]
+        except (OSError, ValueError):
+            return False
+    return bool(addresses) and all(address.is_global for address in addresses)
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def _horde_image_payload(
+    value: Any,
+    *,
+    attempts: list[dict[str, Any]],
+    timeout: float,
+) -> bytes:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("Stable Horde returned no image payload")
+    raw = value.strip()
+    if raw.startswith(("https://", "http://")):
+        opener = urllib.request.build_opener(_NoRedirectHandler())
+        current_url = raw
+        for redirect_index in range(4):
+            if not _public_horde_image_url(current_url):
+                raise ValueError("Stable Horde returned an unsafe image URL")
+            request = urllib.request.Request(
+                current_url,
+                headers={
+                    "User-Agent": "VayboMeter-KLD/1.0",
+                    "Accept": "image/png,image/jpeg,image/webp",
+                },
+                method="GET",
+            )
+            attempt_number = len(attempts) + 1
+            try:
+                response = opener.open(request, timeout=timeout)
+            except HTTPError as exc:
+                if exc.code in {301, 302, 303, 307, 308} and redirect_index < 3:
+                    location = str(exc.headers.get("Location") or "").strip()
+                    attempts.append(
+                        {
+                            "attempt": attempt_number,
+                            "stage": "image_redirect",
+                            "exception_type": "",
+                            "http_status": int(exc.code),
+                            "message": "",
+                            "payload_bytes": 0,
+                        }
+                    )
+                    if not location:
+                        raise ValueError("Stable Horde image redirect had no location") from exc
+                    current_url = urljoin(current_url, location)
+                    continue
+                item = _exception_attempt(attempt_number, exc)
+                item["stage"] = "image_download"
+                attempts.append(item)
+                raise
+            except Exception as exc:
+                item = _exception_attempt(attempt_number, exc)
+                item["stage"] = "image_download"
+                attempts.append(item)
+                raise
+            try:
+                content_type = str(response.headers.get("Content-Type") or "").lower()
+                if not content_type.startswith("image/"):
+                    raise ValueError("Stable Horde image URL returned non-image content")
+                payload = response.read(25 * 1024 * 1024 + 1)
+                if len(payload) > 25 * 1024 * 1024:
+                    raise ValueError("Stable Horde image exceeded the payload limit")
+                attempts.append(
+                    {
+                        "attempt": attempt_number,
+                        "stage": "image_download",
+                        "exception_type": "",
+                        "http_status": int(getattr(response, "status", 200) or 200),
+                        "message": "",
+                        "payload_bytes": len(payload),
+                    }
+                )
+                return payload
+            except Exception as exc:
+                item = _exception_attempt(attempt_number, exc)
+                item["stage"] = "image_download"
+                attempts.append(item)
+                raise
+            finally:
+                response.close()
+        raise ValueError("Stable Horde image redirect limit exceeded")
+    if raw.lower().startswith("data:"):
+        header, separator, raw = raw.partition(",")
+        if not separator or ";base64" not in header.lower() or not header[5:].lower().startswith("image/"):
+            raise ValueError("Stable Horde returned an invalid image data URL")
+    try:
+        return base64.b64decode(raw, validate=True)
+    except Exception as exc:
+        raise ValueError("Stable Horde returned invalid base64 image data") from exc
+
+
+def _validated_horde_jpeg(payload: bytes) -> bytes:
+    if len(payload) < 128:
+        raise ValueError("Stable Horde image response is too small")
+    try:
+        from PIL import Image
+
+        with Image.open(io.BytesIO(payload)) as image:
+            image.load()
+            if image.width < 256 or image.height < 256:
+                raise ValueError("Stable Horde image dimensions are too small")
+    except ImportError:
+        if _sniff_ext(payload, None) is None:
+            raise ValueError("Stable Horde returned an unsupported image payload")
+    jpeg, _mode = _to_jpeg_bytes(payload)
+    if _sniff_ext(jpeg, "image/jpeg") != ".jpg":
+        raise ValueError("Stable Horde image could not be normalized")
+    return jpeg
+
+
+def generate_kld_stable_horde_image(*args, **kwargs) -> str:
+    """Generate through anonymous/configured Stable Horde as the bounded second backend."""
+    if not stable_horde_enabled():
+        raise ImageGenerationError(
+            "Stable Horde backend is disabled",
+            backend="stable_horde",
+            reason="backend_disabled",
+            attempts=[],
+        )
+
+    prompt, style_name, out_path, extra = _extract_args(args, kwargs)
+    final_prompt = (prompt.strip() + (f" style:{style_name}" if style_name else "")).strip()
+    seed = extra.get("seed")
+    if seed is None:
+        seed = _sha_seed(final_prompt)
+    width = min(768, max(512, int(extra.get("width") or 512)))
+    height = min(768, max(512, int(extra.get("height") or 512)))
+    width -= width % 64
+    height -= height % 64
+    if out_path is None:
+        DEFAULT_DIR.mkdir(parents=True, exist_ok=True)
+        out_path = str(DEFAULT_DIR / f"kld_horde_{int(seed)}.jpg")
+    output = Path(out_path).with_suffix(".jpg")
+    _ensure_parent(output)
+
+    api_key = (
+        os.getenv("KLD_STABLE_HORDE_API_KEY", "").strip()
+        or os.getenv("AI_HORDE_API_KEY", "").strip()
+        or os.getenv("HORDE_API_KEY", "").strip()
+        or "0000000000"
+    )
+    headers = {
+        "User-Agent": "VayboMeter-KLD/1.0",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "apikey": api_key,
+    }
+    total_timeout = max(30.0, float(os.getenv("KLD_STABLE_HORDE_TIMEOUT", "90")))
+    poll_interval = max(2.0, float(os.getenv("KLD_STABLE_HORDE_POLL_INTERVAL", "5")))
+    attempts: list[dict[str, Any]] = []
+    started = time.monotonic()
+    try:
+        submission = _horde_json_request(
+            f"{HORDE_BASE_URL}/generate/async",
+            method="POST",
+            headers=headers,
+            attempts=attempts,
+            stage="submit",
+            timeout=15,
+            payload={
+                "prompt": final_prompt,
+                "params": {
+                    "width": width,
+                    "height": height,
+                    "steps": 24,
+                    "n": 1,
+                    "cfg_scale": 7,
+                    "sampler_name": "k_euler",
+                    "seed": str(int(seed)),
+                },
+                "nsfw": False,
+                "censor_nsfw": True,
+                "trusted_workers": False,
+                "shared": True,
+            },
+        )
+        job_id = str(submission.get("id") or "").strip()
+        if not job_id:
+            raise ValueError("Stable Horde submission returned no job id")
+
+        while True:
+            if time.monotonic() - started >= total_timeout:
+                raise TimeoutError(f"Stable Horde timed out after {total_timeout:.0f}s")
+            check = _horde_json_request(
+                f"{HORDE_BASE_URL}/generate/check/{job_id}",
+                method="GET",
+                headers=headers,
+                attempts=attempts,
+                stage="check",
+                timeout=12,
+            )
+            if check.get("faulted") or check.get("cancelled"):
+                raise RuntimeError("Stable Horde job faulted or was cancelled")
+            if check.get("done") or check.get("finished"):
+                break
+            time.sleep(poll_interval)
+
+        status = _horde_json_request(
+            f"{HORDE_BASE_URL}/generate/status/{job_id}",
+            method="GET",
+            headers=headers,
+            attempts=attempts,
+            stage="status",
+            timeout=20,
+        )
+        generations = status.get("generations")
+        if not isinstance(generations, list) or not generations:
+            raise ValueError("Stable Horde returned no generations")
+        generation = generations[0]
+        if not isinstance(generation, dict) or generation.get("censored"):
+            raise ValueError("Stable Horde generation was unavailable or censored")
+        payload = _horde_image_payload(
+            generation.get("img"),
+            attempts=attempts,
+            timeout=min(30.0, total_timeout),
+        )
+        jpeg = _validated_horde_jpeg(payload)
+        output.write_bytes(jpeg)
+    except Exception as exc:
+        diagnostics = {
+            "backend": "stable_horde",
+            "http_attempt_count": len(attempts),
+            "attempts": attempts,
+            "result": "failed",
+            "exception_type": type(exc).__name__,
+        }
+        _set_generation_diagnostics("stable_horde", diagnostics)
+        raise ImageGenerationError(
+            f"Stable Horde generation failed: {exc}",
+            backend="stable_horde",
+            reason="provider_failure",
+            attempts=attempts,
+        ) from exc
+
+    _set_generation_diagnostics(
+        "stable_horde",
+        {
+            "backend": "stable_horde",
+            "http_attempt_count": len(attempts),
+            "attempts": attempts,
+            "result": "success",
+            "elapsed_seconds": round(time.monotonic() - started, 3),
+        },
+    )
+    return str(output)
 
 
 # Compatibility aliases

--- a/kld_informative_cover.py
+++ b/kld_informative_cover.py
@@ -14,7 +14,7 @@ from weather_text import clause_has_confirmed_storm as _clause_has_confirmed_sto
 from weather_text import split_clauses as _split_clauses
 
 
-RENDERER_VERSION = "kld_local_informative_cover_v1"
+RENDERER_VERSION = "kld_local_informative_cover_v2"
 _NUMBER = r"-?\d+(?:[.,]\d+)?"
 _CITY_TEMPERATURE_RE = re.compile(
     rf"Калининград[^\n]*?({_NUMBER})\s*/\s*({_NUMBER})\s*°?C?",
@@ -28,10 +28,21 @@ _WAVE_RE = re.compile(rf"волна\s*({_NUMBER})\s*м", re.IGNORECASE)
 _DATE_RE = re.compile(r"\b(\d{2}\.\d{2}\.\d{4})\b")
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
 _EDITORIAL_LINE_RE = re.compile(
-    r"^\W*(?:главный\s+нюанс|нюанс|vaybometer|план|рекомендации|уверенность)"
+    r"^\W*(?:главный\s+нюанс|нюанс|главное|настрой|vaybometer|план|рекомендации|уверенность)"
     r"(?:\s+[^:]{1,32})?\s*:",
     re.IGNORECASE,
 )
+_DECORATIVE_SECTION_RE = re.compile(
+    r"^(?:❄️?\s*)?(?:самые\s+прохладные\s+ночи|самые\s+тёплые\s+дни|"
+    r"морские\s+города|внутри\s+области|тёплые\s+города|прохладные\s+города|"
+    r"солнце(?:,\s*луна)?\s+и\s+ритм|астроритм)\s*:?\s*$",
+    re.IGNORECASE,
+)
+_STRUCTURED_WEATHER_LINE_RE = re.compile(
+    rf"^[^:\n—–]{{2,48}}(?::|—|–)\s*[^\n]*?{_NUMBER}\s*/\s*{_NUMBER}\s*°?\s*C?(?:\s*•|\s*$)",
+    re.IGNORECASE,
+)
+_LINE_TEMPERATURE_RE = re.compile(rf"({_NUMBER})\s*/\s*({_NUMBER})\s*°?\s*C?", re.IGNORECASE)
 # "шторм" word/negation/uncertainty detection is shared with format_v2.py,
 # safe_test_post.py and post_kld.py via weather_text.clause_has_confirmed_storm,
 # so all four use one contract. "гроза" (thunderstorm) is a separate concept
@@ -77,7 +88,7 @@ _UNCERTAIN_SUFFIX_AFTER = r"провер\w*|уточн\w*|возмож\w*|вер
 _PRECIP_GROUP_STEMS = {
     "rain": ("дожд", "лив"),
     "drizzle": ("морос",),
-    "snow": ("снег",),
+    "snow": ("снег", "снеж"),
     "precipitation": ("осадк",),
 }
 
@@ -126,7 +137,8 @@ _RAIN_WORD_RE = re.compile(r"(?:дожд\w*|лив\w*)", re.IGNORECASE)
 _RAIN_ICON_RE = re.compile(r"🌧")
 _SHOWERS_ICON_RE = re.compile(r"🌦")
 _DRIZZLE_RE = re.compile(r"морос\w*", re.IGNORECASE)
-_SNOW_RE = re.compile(r"(?:❄|снег\w*)", re.IGNORECASE)
+_SNOW_WORD_RE = re.compile(r"(?:снег\w*|снеж\w*)", re.IGNORECASE)
+_SNOW_ICON_RE = re.compile(r"❄")
 _PRECIPITATION_RE = re.compile(r"осад\w*", re.IGNORECASE)
 _STRONG_WIND_RE = re.compile(r"(?:сильн\w*\s+ветер|штормов\w*\s+ветер)", re.IGNORECASE)
 
@@ -155,6 +167,27 @@ def _precip_group_confirmed(group_key: str, clause: str, *, has_evidence: bool) 
     return True
 
 
+def _is_decorative_section_line(line: str) -> bool:
+    """Return True for editorial/ranking headers that are not weather observations."""
+    cleaned = _HTML_TAG_RE.sub("", str(line or "")).strip()
+    cleaned = re.sub(r"^[\s•·—–-]+", "", cleaned)
+    return bool(_DECORATIVE_SECTION_RE.match(cleaned))
+
+
+def _structured_snow_icon_is_factual(line: str, clause: str) -> bool:
+    """Accept a bare snow icon only as a plausible structured city condition."""
+    if not _SNOW_ICON_RE.search(clause) or not _STRUCTURED_WEATHER_LINE_RE.search(line):
+        return False
+    match = _LINE_TEMPERATURE_RE.search(line)
+    if not match:
+        return False
+    temperatures = tuple(_number(value) for value in match.groups())
+    valid_temperatures = tuple(value for value in temperatures if value is not None)
+    # A decorative icon in a positive-temperature summer row is not enough to
+    # publish a snow badge. An explicit snow/snowy word remains valid evidence.
+    return bool(valid_temperatures) and max(valid_temperatures) <= 2.0
+
+
 def _number(value: object) -> float | None:
     try:
         return float(str(value).replace(",", "."))
@@ -177,8 +210,8 @@ def _first_match(pattern: re.Pattern[str], text: str) -> tuple[float, ...]:
     return tuple(value for value in values if value is not None)
 
 
-def _factual_weather_truth(message: str) -> dict[str, bool]:
-    """Parse explicit weather facts without promoting editorial advice to observations."""
+def _factual_weather_analysis(message: str) -> tuple[dict[str, bool], dict[str, list[str]]]:
+    """Parse explicit facts and retain the source lines that proved each flag."""
     explicit_storm = False
     actual_precipitation = False
     rain = False
@@ -187,10 +220,25 @@ def _factual_weather_truth(message: str) -> dict[str, bool]:
     thunderstorm = False
     strong_wind = False
     max_gust: float | None = None
+    evidence: dict[str, list[str]] = {
+        "explicit_storm": [],
+        "rain": [],
+        "drizzle": [],
+        "snow": [],
+        "thunderstorm": [],
+        "strong_wind": [],
+        "precipitation": [],
+    }
+
+    def remember(kind: str, source_line: str) -> None:
+        rendered = source_line.strip()
+        if rendered and rendered not in evidence[kind]:
+            evidence[kind].append(rendered)
 
     for raw_line in message.splitlines():
-        line = _HTML_TAG_RE.sub("", raw_line).strip().lower()
-        if not line or _EDITORIAL_LINE_RE.match(line):
+        clean_line = _HTML_TAG_RE.sub("", raw_line).strip()
+        line = clean_line.lower()
+        if not line or _EDITORIAL_LINE_RE.match(line) or _is_decorative_section_line(clean_line):
             continue
 
         # Gust value via the single shared parser (weather_text), counting only
@@ -204,6 +252,7 @@ def _factual_weather_truth(message: str) -> dict[str, bool]:
         # storm_gust, which is a strict >=STORM_GUST_MS test derived below.
         if (gust is not None and gust >= 12) or _STRONG_WIND_RE.search(line):
             strong_wind = True
+            remember("strong_wind", clean_line)
 
         # Split into clauses (sentence punctuation, or ", но"/", а" joining two
         # independent statements) so a negation in one clause ("Шторма не будет
@@ -222,11 +271,14 @@ def _factual_weather_truth(message: str) -> dict[str, bool]:
             # is the separate derived `severe_weather` flag computed below.
             if _clause_has_confirmed_storm(clause):
                 explicit_storm = True
+                remember("explicit_storm", clean_line)
             if _thunderstorm_confirmed(clause):
                 thunderstorm = True
+                remember("thunderstorm", clean_line)
 
             drizzle_evidence = bool(_DRIZZLE_RE.search(clause))
-            snow_evidence = bool(_SNOW_RE.search(clause))
+            explicit_snow_word = bool(_SNOW_WORD_RE.search(clause))
+            snow_evidence = explicit_snow_word or _structured_snow_icon_is_factual(line, clause)
             explicit_rain_evidence = bool(_RAIN_WORD_RE.search(clause) or _RAIN_ICON_RE.search(clause))
             showers_icon = bool(_SHOWERS_ICON_RE.search(clause))
             rain_evidence = explicit_rain_evidence or (
@@ -243,6 +295,14 @@ def _factual_weather_truth(message: str) -> dict[str, bool]:
             rain = rain or clause_rain
             drizzle = drizzle or clause_drizzle
             snow = snow or clause_snow
+            if clause_rain:
+                remember("rain", clean_line)
+            if clause_drizzle:
+                remember("drizzle", clean_line)
+            if clause_snow:
+                remember("snow", clean_line)
+            if clause_precipitation:
+                remember("precipitation", clean_line)
             actual_precipitation = actual_precipitation or any(
                 (clause_rain, clause_drizzle, clause_snow, clause_precipitation)
             )
@@ -259,7 +319,7 @@ def _factual_weather_truth(message: str) -> dict[str, bool]:
     # severe_weather is the umbrella for the dramatic palette: storm word,
     # thunderstorm, or gust-threshold storm.
     severe_weather = explicit_storm or thunderstorm or storm_gust
-    return {
+    flags = {
         "explicit_storm": explicit_storm,
         "actual_precipitation": actual_precipitation,
         "rain": rain,
@@ -271,6 +331,13 @@ def _factual_weather_truth(message: str) -> dict[str, bool]:
         "severe_weather": severe_weather,
         "strong_wind": strong_wind,
     }
+    return flags, evidence
+
+
+def _factual_weather_truth(message: str) -> dict[str, bool]:
+    """Parse explicit weather facts without promoting editorial advice to observations."""
+    flags, _evidence = _factual_weather_analysis(message)
+    return flags
 
 
 def _precipitation_display(factual: Mapping[str, bool]) -> str:
@@ -300,10 +367,10 @@ def _weather_flags(
     visibility_context: Mapping[str, Any] | None,
     *,
     post_type: str,
-) -> dict[str, bool | str]:
+) -> dict[str, Any]:
     lowered = message.lower()
     condition = str((visibility_context or {}).get("visibility_condition") or "").strip().lower()
-    factual = _factual_weather_truth(message)
+    factual, evidence = _factual_weather_analysis(message)
     weather_main = "unknown"
     try:
         from visual_context_kld import build_visual_context
@@ -337,6 +404,7 @@ def _weather_flags(
         "weather_main": weather_main,
         "storm": factual["explicit_storm"],
         **factual,
+        "evidence": evidence,
         "precipitation_display": _precipitation_display(factual),
         "fog": fog,
         "dust_haze": dust,
@@ -434,6 +502,89 @@ def extract_kld_cover_facts(
             "wave_m": wave[0] if wave else None,
             "visibility_m": visibility_actual,
         },
+    }
+
+
+def validate_kld_cover_semantics(
+    message: str,
+    cover_metadata: Mapping[str, Any],
+    *,
+    post_type: str,
+    visibility_context: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Verify that a rendered cover is a faithful projection of its source facts."""
+    expected = extract_kld_cover_facts(
+        message,
+        post_type=post_type,
+        visibility_context=visibility_context,
+    )
+    errors: list[str] = []
+    actual_facts = list(cover_metadata.get("facts") or [])
+    expected_facts = list(expected.get("facts") or [])
+    if actual_facts != expected_facts:
+        errors.append("display facts differ from deterministic source extraction")
+
+    actual_weather = cover_metadata.get("weather")
+    expected_weather = expected["weather"]
+    if not isinstance(actual_weather, Mapping):
+        errors.append("weather metadata is missing")
+        actual_weather = {}
+    truth_keys = (
+        "explicit_storm",
+        "actual_precipitation",
+        "rain",
+        "drizzle",
+        "snow",
+        "thunderstorm",
+        "storm_gust",
+        "storm_badge",
+        "severe_weather",
+        "strong_wind",
+        "fog",
+        "dust_haze",
+        "mixed_visibility",
+        "reduced_visibility",
+        "precipitation_display",
+    )
+    for key in truth_keys:
+        if actual_weather.get(key) != expected_weather.get(key):
+            errors.append(f"weather flag mismatch: {key}")
+
+    actual_values = cover_metadata.get("actual_values")
+    expected_values = expected["actual_values"]
+    if not isinstance(actual_values, Mapping):
+        errors.append("actual value metadata is missing")
+        actual_values = {}
+    for key, expected_value in expected_values.items():
+        actual_value = actual_values.get(key)
+        if isinstance(expected_value, (int, float)) or isinstance(actual_value, (int, float)):
+            if expected_value is None or actual_value is None or abs(float(expected_value) - float(actual_value)) > 0.01:
+                errors.append(f"actual value mismatch: {key}")
+        elif actual_value != expected_value:
+            errors.append(f"actual value mismatch: {key}")
+
+    evidence = expected_weather.get("evidence")
+    evidence = dict(evidence) if isinstance(evidence, Mapping) else {}
+    for flag in ("explicit_storm", "rain", "drizzle", "snow", "thunderstorm"):
+        if expected_weather.get(flag) and not evidence.get(flag):
+            errors.append(f"missing source evidence: {flag}")
+
+    snow_evidence = [str(line) for line in evidence.get("snow") or []]
+    if expected_weather.get("snow") and snow_evidence:
+        explicit_snow = any(_SNOW_WORD_RE.search(line) for line in snow_evidence)
+        plausible_structured_icon = any(
+            _structured_snow_icon_is_factual(line.lower(), line.lower()) for line in snow_evidence
+        )
+        if not explicit_snow and not plausible_structured_icon:
+            errors.append("snow is not supported by an explicit or structured weather fact")
+
+    return {
+        "valid": not errors,
+        "errors": errors,
+        "checked_facts": actual_facts,
+        "expected_facts": expected_facts,
+        "source_evidence": evidence,
+        "precipitation_display": expected_weather.get("precipitation_display"),
     }
 
 
@@ -631,4 +782,5 @@ __all__ = [
     "RENDERER_VERSION",
     "extract_kld_cover_facts",
     "render_kld_informative_cover",
+    "validate_kld_cover_semantics",
 ]

--- a/tools/kld_visual_fixture_image.py
+++ b/tools/kld_visual_fixture_image.py
@@ -42,10 +42,12 @@ from image_prompt_kld_morning import build_kld_morning_prompt  # noqa: E402
 from kld_informative_cover import (  # noqa: E402
     RENDERER_VERSION as LOCAL_COVER_RENDERER_VERSION,
     render_kld_informative_cover,
+    validate_kld_cover_semantics,
 )
 from kld_visual_dedup import (  # noqa: E402
     evaluate_kld_visual_candidate,
     kld_visual_history_path,
+    load_kld_visual_history,
     record_kld_visual_publication,
 )
 from visual_context_kld import build_visual_context  # noqa: E402
@@ -259,14 +261,35 @@ def _base_outcome(*, post_type: str) -> dict[str, Any]:
         "telegram_image_message_id": None,
         "history_recorded": False,
         "cover_attempted": False,
+        "cover_validation": None,
+        "local_cover_published": False,
         "post_type": post_type,
         "provider_error": None,
+        "provider_errors": [],
+        "provider_attempts": [],
+        "http_attempt_count": 0,
+        "fallback_reason": "",
+        "selected_scene_family": "",
+        "selected_composition": "",
+        "selected_cache_key": "",
+        "dedup_reason": "",
+        "dedup_distance": None,
+        "scene_cooldown": [],
+        "composition_cooldown": [],
         "dedup_results": [],
     }
 
 
-def _error_payload(exc: Exception) -> dict[str, str]:
-    return {"type": type(exc).__name__, "message": str(exc)}
+def _error_payload(exc: Exception) -> dict[str, Any]:
+    attempts = list(getattr(exc, "attempts", []) or [])
+    return {
+        "type": type(exc).__name__,
+        "message": str(exc),
+        "backend": str(getattr(exc, "backend", "") or ""),
+        "reason": str(getattr(exc, "reason", "") or ""),
+        "http_attempt_count": len(attempts),
+        "attempts": attempts,
+    }
 
 
 def _duplicate_payload(duplicate: Any, *, attempt: int, backend: str) -> dict[str, Any]:
@@ -305,6 +328,9 @@ def _send_and_record(
 ) -> dict[str, Any]:
     outcome["backend"] = backend
     outcome["image_path"] = image_path
+    outcome["selected_scene_family"] = str(metadata.get("scene_family") or "")
+    outcome["selected_composition"] = str(metadata.get("composition") or "")
+    outcome["selected_cache_key"] = cache_key
     if not args.send_to_test:
         outcome["result"] = "generated"
         return outcome
@@ -325,7 +351,8 @@ def _send_and_record(
 
     outcome["telegram_image_sent"] = True
     outcome["telegram_image_message_id"] = message_id
-    outcome["result"] = "fallback_sent" if backend == "local_informative_cover" else "sent"
+    outcome["local_cover_published"] = backend == "local_informative_cover"
+    outcome["result"] = "sent" if backend == "pollinations" else "fallback_sent"
     try:
         entry = record_publication(
             date_value=str(metadata["forecast_date"]),
@@ -354,6 +381,124 @@ def _send_and_record(
     return outcome
 
 
+def _recent_visual_cooldown(history_path: Path) -> tuple[list[str], list[str]]:
+    scenes: list[str] = []
+    compositions: list[str] = []
+    for entry in reversed(load_kld_visual_history(history_path)):
+        scene = str(entry.get("scene_family") or "")
+        composition = str(entry.get("composition") or "")
+        if scene and scene != "local_informative_cover" and scene not in scenes and len(scenes) < 3:
+            scenes.append(scene)
+        if composition and composition != "branded_weather_card" and composition not in compositions and len(compositions) < 4:
+            compositions.append(composition)
+        if len(scenes) >= 3 and len(compositions) >= 4:
+            break
+    return scenes, compositions
+
+
+def _candidate_payloads(
+    *,
+    args: argparse.Namespace,
+    message: str,
+    visibility_context: Mapping[str, Any] | None,
+    history_path: Path,
+    count: int = 3,
+) -> tuple[list[dict[str, Any]], list[str], list[str]]:
+    blocked_scenes, blocked_compositions = _recent_visual_cooldown(history_path)
+
+    def payload_for(variation_attempt: int) -> dict[str, Any]:
+        if args.message_file:
+            return build_payload(
+                message,
+                "message_file",
+                post_type=args.post_type,
+                variation_attempt=variation_attempt,
+                visibility_context=visibility_context,
+            )
+        return build_fixture_payload(
+            args.scenario,
+            post_type=args.post_type,
+            variation_attempt=variation_attempt,
+        )
+
+    context = build_visual_context(
+        message,
+        post_type=args.post_type,
+        visibility_context=visibility_context,
+    )
+    date_key = _extract_prompt_date(message, dt.date(2026, 6, 19))
+    candidate_metadata = [
+        (
+            index,
+            kld_scene_metadata(
+                context,
+                date_key=date_key,
+                post_type=args.post_type,
+                source_text=message,
+                variation_attempt=index,
+            ),
+        )
+        for index in range(48)
+    ]
+    selected_attempts: list[int] = []
+    used_scenes: set[str] = set()
+    used_compositions: set[str] = set()
+    for cooldown_mode in ("strict", "scene_only", "relaxed"):
+        for variation_attempt, metadata in candidate_metadata:
+            scene = str(metadata["scene_family"])
+            composition = str(metadata["composition"])
+            if scene in used_scenes or composition in used_compositions:
+                continue
+            if cooldown_mode in {"strict", "scene_only"} and scene in blocked_scenes:
+                continue
+            if cooldown_mode == "strict" and composition in blocked_compositions:
+                continue
+            selected_attempts.append(variation_attempt)
+            used_scenes.add(scene)
+            used_compositions.add(composition)
+            if len(selected_attempts) >= count:
+                return (
+                    [payload_for(attempt) for attempt in selected_attempts],
+                    blocked_scenes,
+                    blocked_compositions,
+                )
+    return (
+        [payload_for(attempt) for attempt in selected_attempts[:count]],
+        blocked_scenes,
+        blocked_compositions,
+    )
+
+
+def _provider_attempt_payload(
+    *,
+    backend: str,
+    candidate: Mapping[str, Any],
+    result: str,
+    diagnostics: Mapping[str, Any] | None = None,
+    error: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    metadata = candidate["metadata"]
+    diagnostics = dict(diagnostics or {})
+    error = dict(error or {})
+    http_attempts = list(diagnostics.get("attempts") or error.get("attempts") or [])
+    return {
+        "backend": backend,
+        "variation_attempt": int(candidate.get("variation_attempt") or 0),
+        "scene_family": str(metadata.get("scene_family") or ""),
+        "composition": str(metadata.get("composition") or ""),
+        "cache_key": str(candidate.get("cache_key") or ""),
+        "result": result,
+        "exception_type": str(error.get("type") or diagnostics.get("exception_type") or ""),
+        "error_message": str(error.get("message") or ""),
+        "http_attempt_count": int(
+            diagnostics.get("http_attempt_count")
+            or error.get("http_attempt_count")
+            or len(http_attempts)
+        ),
+        "http_attempts": http_attempts,
+    }
+
+
 def execute_image_delivery(
     *,
     args: argparse.Namespace,
@@ -362,111 +507,176 @@ def execute_image_delivery(
     visibility_context: Mapping[str, Any] | None,
     history_path: Path,
     generate_image: Callable[..., str] | None = None,
+    secondary_generate_image: Callable[..., str] | None = None,
+    provider_diagnostics: Callable[[str], Mapping[str, Any]] | None = None,
     evaluate_candidate: Callable[..., Any] = evaluate_kld_visual_candidate,
     cover_renderer: Callable[..., Mapping[str, Any]] = render_kld_informative_cover,
+    validate_cover: Callable[..., Mapping[str, Any]] = validate_kld_cover_semantics,
     send_photo: Callable[..., int | None] | None = None,
     record_publication: Callable[..., Mapping[str, Any]] = record_kld_visual_publication,
 ) -> dict[str, Any]:
-    """Attempt AI image, then a local factual cover, without fatal image-only exits."""
+    """Try two providers, then a validated factual cover, without fatal image-only exits."""
     if generate_image is None:
         import imagegen
 
         generate_image = imagegen.generate_kld_evening_image
+        if imagegen.stable_horde_enabled():
+            secondary_generate_image = imagegen.generate_kld_stable_horde_image
+        provider_diagnostics = imagegen.get_generation_diagnostics
     if send_photo is None:
         send_photo = lambda path, caption, chat_id_override="": asyncio.run(  # noqa: E731
             _send_photo(path, caption, chat_id_override=chat_id_override)
         )
 
     outcome = _base_outcome(post_type=args.post_type)
-    selected: tuple[dict[str, Any], str, Any] | None = None
-    least_similar: tuple[dict[str, Any], str, Any] | None = None
-    fallback_reason = ""
-
-    for attempt in range(3):
-        candidate = (
-            build_payload(
-                message,
-                "message_file",
-                post_type=args.post_type,
-                variation_attempt=attempt,
-                visibility_context=visibility_context,
-            )
-            if args.message_file
-            else build_fixture_payload(args.scenario, post_type=args.post_type, variation_attempt=attempt)
-        )
-        try:
-            img_path = generate_image(
-                prompt=candidate["image_prompt"],
-                style_name=candidate["style_name"],
-                seed=_seed_from_cache_key(candidate["cache_key"]),
-            )
-            print(f"Generated KLD image attempt={attempt}: {img_path}")
+    providers = [("pollinations", generate_image)]
+    if secondary_generate_image is not None:
+        providers.append(("stable_horde", secondary_generate_image))
+    candidates, scene_cooldown, composition_cooldown = _candidate_payloads(
+        args=args,
+        message=message,
+        visibility_context=visibility_context,
+        history_path=history_path,
+        count=3 * len(providers),
+    )
+    outcome["scene_cooldown"] = scene_cooldown
+    outcome["composition_cooldown"] = composition_cooldown
+    duplicate_reasons: list[str] = []
+    provider_failed = False
+    provider_failure_kinds: list[str] = []
+    for provider_index, (backend, generator) in enumerate(providers):
+        start = provider_index * 3
+        provider_candidates = candidates[start : start + 3]
+        for candidate in provider_candidates:
             metadata = candidate["metadata"]
-            duplicate = evaluate_candidate(
-                img_path,
-                date_value=metadata["forecast_date"],
-                target_date=metadata["target_date"],
-                post_type=args.post_type,
-                scene_family=metadata["scene_family"],
-                composition=metadata["composition"],
-                prompt_version=metadata["prompt_version"],
-                history_path=history_path,
+            try:
+                img_path = generator(
+                    prompt=candidate["image_prompt"],
+                    style_name=candidate["style_name"],
+                    seed=_seed_from_cache_key(candidate["cache_key"]),
+                )
+            except Exception as exc:
+                provider_failed = True
+                error = _error_payload(exc)
+                if not error["backend"]:
+                    error["backend"] = backend
+                outcome["provider_error"] = error
+                outcome["provider_errors"].append(error)
+                outcome["error_type"] = error["type"]
+                outcome["error_message"] = error["message"]
+                provider_failure_kinds.append(str(error.get("reason") or "provider_failure"))
+                if backend == "pollinations":
+                    outcome["fallback_reason"] = str(error.get("reason") or "provider_failure")
+                attempt_payload = _provider_attempt_payload(
+                    backend=backend,
+                    candidate=candidate,
+                    result="failed",
+                    error=error,
+                )
+                outcome["provider_attempts"].append(attempt_payload)
+                outcome["http_attempt_count"] += attempt_payload["http_attempt_count"]
+                print(
+                    "WARNING: KLD image provider unavailable: "
+                    f"backend={backend} {error['type']}: {error['message']}"
+                )
+                break
+
+            diagnostics = provider_diagnostics(backend) if provider_diagnostics else {}
+            attempt_payload = _provider_attempt_payload(
+                backend=backend,
+                candidate=candidate,
+                result="generated",
+                diagnostics=diagnostics,
             )
-        except Exception as exc:
-            error = _error_payload(exc)
-            outcome["provider_error"] = error
-            outcome["error_type"] = error["type"]
-            outcome["error_message"] = error["message"]
-            fallback_reason = "provider_failure"
-            print(f"WARNING: KLD AI image unavailable: {error['type']}: {error['message']}")
-            print("::warning::KLD AI image failed; local informative cover will be attempted.")
-            break
+            outcome["provider_attempts"].append(attempt_payload)
+            outcome["http_attempt_count"] += attempt_payload["http_attempt_count"]
+            print(
+                "Generated KLD image: "
+                f"backend={backend} variation={candidate['variation_attempt']} "
+                f"scene={metadata['scene_family']} composition={metadata['composition']} path={img_path}"
+            )
+            try:
+                duplicate = evaluate_candidate(
+                    img_path,
+                    date_value=metadata["forecast_date"],
+                    target_date=metadata["target_date"],
+                    post_type=args.post_type,
+                    scene_family=metadata["scene_family"],
+                    composition=metadata["composition"],
+                    prompt_version=metadata["prompt_version"],
+                    history_path=history_path,
+                )
+            except Exception as exc:
+                provider_failed = True
+                error = _error_payload(exc)
+                error["backend"] = backend
+                error["reason"] = "invalid_image"
+                provider_failure_kinds.append("invalid_image")
+                outcome["provider_error"] = error
+                outcome["provider_errors"].append(error)
+                outcome["error_type"] = error["type"]
+                outcome["error_message"] = error["message"]
+                outcome["provider_attempts"][-1]["result"] = "invalid_image"
+                outcome["provider_attempts"][-1]["exception_type"] = error["type"]
+                outcome["provider_attempts"][-1]["error_message"] = error["message"]
+                print(f"WARNING: KLD generated image validation failed: {error['type']}: {error['message']}")
+                break
 
-        dedup = _duplicate_payload(duplicate, attempt=attempt, backend="pollinations")
-        outcome["dedup_results"].append(dedup)
-        print(
-            "KLD image duplicate check: "
-            f"attempt={attempt} accepted={duplicate.accepted} reason={duplicate.reason} "
-            f"scene={metadata['scene_family']} composition={metadata['composition']} "
-            f"min_distance={duplicate.min_distance}"
+            dedup = _duplicate_payload(
+                duplicate,
+                attempt=int(candidate["variation_attempt"]),
+                backend=backend,
+            )
+            outcome["dedup_results"].append(dedup)
+            outcome["dedup_reason"] = dedup["reason"]
+            outcome["dedup_distance"] = dedup["min_distance"]
+            outcome["provider_attempts"][-1]["dedup_reason"] = dedup["reason"]
+            outcome["provider_attempts"][-1]["dedup_distance"] = dedup["min_distance"]
+            print(
+                "KLD image duplicate check: "
+                f"backend={backend} variation={candidate['variation_attempt']} "
+                f"accepted={duplicate.accepted} reason={duplicate.reason} "
+                f"scene={metadata['scene_family']} composition={metadata['composition']} "
+                f"min_distance={duplicate.min_distance}"
+            )
+            if duplicate.accepted:
+                print(f"Selected KLD image: backend={backend} path={img_path}")
+                return _send_and_record(
+                    args=args,
+                    outcome=outcome,
+                    backend=backend,
+                    image_path=img_path,
+                    metadata=metadata,
+                    cache_key=candidate["cache_key"],
+                    style_name=candidate["style_name"],
+                    history_path=history_path,
+                    send_photo=send_photo,
+                    record_publication=record_publication,
+                )
+            duplicate_reasons.append(str(duplicate.reason))
+            # Hard rejection: a near duplicate is never promoted merely because
+            # it is the least similar of the rejected candidates.
+
+    if provider_failed and duplicate_reasons:
+        fallback_reason = "provider_failure_after_duplicate"
+    elif provider_failed:
+        fallback_reason = (
+            "invalid_image"
+            if provider_failure_kinds and all(kind == "invalid_image" for kind in provider_failure_kinds)
+            else "provider_failure"
         )
-        if duplicate.accepted:
-            selected = (candidate, img_path, duplicate)
-            break
-        if duplicate.reason != "exact_duplicate":
-            if least_similar is None:
-                least_similar = (candidate, img_path, duplicate)
-            else:
-                previous_distance = least_similar[2].min_distance
-                current_distance = duplicate.min_distance
-                if current_distance is not None and (previous_distance is None or current_distance > previous_distance):
-                    least_similar = (candidate, img_path, duplicate)
-
-    if selected is None and least_similar is not None:
-        selected = least_similar
-        print("WARNING: all KLD AI candidates were near-duplicates; using least similar candidate.")
-    if selected is not None:
-        payload, img_path, _duplicate = selected
-        print(f"Selected KLD image: {img_path}")
-        return _send_and_record(
-            args=args,
-            outcome=outcome,
-            backend="pollinations",
-            image_path=img_path,
-            metadata=payload["metadata"],
-            cache_key=payload["cache_key"],
-            style_name=payload["style_name"],
-            history_path=history_path,
-            send_photo=send_photo,
-            record_publication=record_publication,
-        )
-
-    if not fallback_reason:
+    elif "near_duplicate" in duplicate_reasons:
+        fallback_reason = "near_duplicate"
+    else:
         fallback_reason = "exact_duplicate"
-        outcome["error_type"] = "ExactDuplicateOnly"
-        outcome["error_message"] = "all AI candidates matched exact visual history entries"
-        print("WARNING: all KLD AI candidates were exact duplicates; trying local informative cover.")
-        print("::warning::KLD AI image duplicate; local informative cover will be attempted.")
+    outcome["fallback_reason"] = fallback_reason
+    if duplicate_reasons and not provider_failed:
+        outcome["error_type"] = "DuplicateOnly"
+        outcome["error_message"] = "all generated candidates matched visual history"
+    print(
+        "::warning::KLD AI image unavailable after provider/dedup ladder; "
+        "validated local informative cover will be attempted."
+    )
 
     outcome["cover_attempted"] = True
     cover_path = str(Path(args.cover_path))
@@ -479,6 +689,29 @@ def execute_image_delivery(
                 output_path=cover_path,
             )
         )
+        outcome["cover_metadata"] = cover_metadata
+        cover_validation = dict(
+            validate_cover(
+                message,
+                cover_metadata,
+                post_type=args.post_type,
+                visibility_context=visibility_context,
+            )
+        )
+        outcome["cover_validation"] = cover_validation
+        if not cover_validation.get("valid"):
+            outcome.update(
+                result="failed_nonfatal",
+                backend="none",
+                error_type="InvalidLocalCover",
+                error_message="; ".join(str(item) for item in cover_validation.get("errors") or []),
+            )
+            print(
+                "WARNING: KLD local informative cover failed semantic validation; "
+                "continuing without image: "
+                + outcome["error_message"]
+            )
+            return outcome
         metadata = initial_payload["metadata"]
         cover_duplicate = evaluate_candidate(
             cover_path,
@@ -502,17 +735,25 @@ def execute_image_delivery(
         print(f"WARNING: KLD local informative cover failed: {error['type']}: {error['message']}")
         return outcome
 
-    outcome["cover_metadata"] = cover_metadata
-    outcome["fallback_reason"] = fallback_reason
-    outcome["dedup_results"].append(_duplicate_payload(cover_duplicate, attempt=0, backend="local_informative_cover"))
-    if str(getattr(cover_duplicate, "reason", "")) == "exact_duplicate":
+    cover_dedup = _duplicate_payload(cover_duplicate, attempt=0, backend="local_informative_cover")
+    outcome["dedup_results"].append(cover_dedup)
+    outcome["dedup_reason"] = cover_dedup["reason"]
+    outcome["dedup_distance"] = cover_dedup["min_distance"]
+    outcome["selected_scene_family"] = "local_informative_cover"
+    outcome["selected_composition"] = "branded_weather_card"
+    outcome["selected_cache_key"] = f"{initial_payload['cache_key']};renderer={LOCAL_COVER_RENDERER_VERSION}"
+    if str(getattr(cover_duplicate, "reason", "")) in {"exact_duplicate", "near_duplicate"}:
         outcome.update(
             result="skipped_duplicate",
             backend="local_informative_cover",
             telegram_image_sent=False,
             history_recorded=False,
         )
-        print("WARNING: KLD local informative cover is an exact duplicate; continuing without image.")
+        print(
+            "WARNING: KLD local informative cover is a duplicate "
+            f"({cover_dedup['reason']}, distance={cover_dedup['min_distance']}); "
+            "continuing without image."
+        )
         return outcome
 
     cover_history_metadata = {

--- a/tools/test_kld_image_first.py
+++ b/tools/test_kld_image_first.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 import argparse
+import base64
+import io
 import json
 import os
 import subprocess
@@ -18,11 +20,13 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from kld_image_first import FORMAT_V2_BEGIN, FORMAT_V2_END, run_image_first_publication  # noqa: E402
+import imagegen  # noqa: E402
 from kld_informative_cover import (  # noqa: E402
     RENDERER_VERSION,
     _factual_weather_truth,
     extract_kld_cover_facts,
     render_kld_informative_cover,
+    validate_kld_cover_semantics,
 )
 from kld_visual_dedup import KldVisualDuplicateResult  # noqa: E402
 from tools.kld_visual_fixture_image import (  # noqa: E402
@@ -66,13 +70,13 @@ def _image(path: Path, color: tuple[int, int, int] = (70, 110, 140)) -> str:
     return str(path)
 
 
-def _duplicate(*, accepted: bool, reason: str) -> KldVisualDuplicateResult:
+def _duplicate(*, accepted: bool, reason: str, distance: int | None = 12) -> KldVisualDuplicateResult:
     return KldVisualDuplicateResult(
         accepted=accepted,
         reason=reason,
         sha256="a" * 64,
         perceptual_hash="0" * 16,
-        min_distance=12,
+        min_distance=distance,
     )
 
 
@@ -104,6 +108,9 @@ def _run_delivery(
     send_photo,
     record,
     post_type: str = "evening",
+    secondary_generate=None,
+    validate_cover=None,
+    provider_diagnostics=None,
 ):
     args = _args(root, post_type=post_type)
     visibility = {
@@ -119,8 +126,11 @@ def _run_delivery(
         visibility_context=visibility,
         history_path=root / "history.json",
         generate_image=generate,
+        secondary_generate_image=secondary_generate,
+        provider_diagnostics=provider_diagnostics,
         evaluate_candidate=evaluate,
         cover_renderer=cover_renderer,
+        validate_cover=validate_cover or (lambda *args, **kwargs: {"valid": True, "errors": []}),
         send_photo=send_photo,
         record_publication=record,
     )
@@ -1073,6 +1083,391 @@ def mixed_regional_precipitation_keeps_text_and_graphics_aligned() -> None:
                 assert (snow_pixels > 0) is snow_graphics, (name, snow_pixels)
 
 
+def production_decorative_snow_headers_are_not_weather_evidence() -> None:
+    cases = {
+        "21_july_rain": (
+            """<b>🌅 Калининградская область завтра (21.07.2026)</b>
+🏙 Калининград: 17/13 °C • 🌧 дождь • 💨 3.5 м/с • порывы до 14 м/с
+❄️ Самые прохладные ночи
+Светлогорск: 16/12 °C • 🌧 дождь
+#Калининград #погода
+""",
+            "rain",
+            "ДОЖДЬ МЕСТАМИ",
+        ),
+        "24_july_drizzle": (
+            """<b>🌅 Калининградская область завтра (24.07.2026)</b>
+🏙 Калининград: 21/14 °C • 🌦 морось • 💨 2.1 м/с • порывы до 7 м/с
+❄️ Самые прохладные ночи
+Пионерский: 19/13 °C • 🌦 морось
+#Калининград #погода
+""",
+            "drizzle",
+            "МОРОСЬ МЕСТАМИ",
+        ),
+        "25_july_cloudy": (
+            """<b>🌅 Калининградская область завтра (25.07.2026)</b>
+🏙 Калининград: 23/15 °C • ☁️ облачно • 💨 3.3 м/с • порывы до 8 м/с
+❄️ Самые прохладные ночи
+Черняховск: 21/12 °C • ☁️ облачно
+#Калининград #погода
+""",
+            "none",
+            "",
+        ),
+    }
+    for name, (message, display, first_fact) in cases.items():
+        metadata = extract_kld_cover_facts(message, post_type="evening")
+        weather = metadata["weather"]
+        assert weather["snow"] is False, (name, weather)
+        assert weather["precipitation_display"] == display, (name, weather)
+        assert not any("СНЕГ" in fact for fact in metadata["facts"]), (name, metadata["facts"])
+        if first_fact:
+            assert metadata["facts"][0] == first_fact, (name, metadata["facts"])
+
+    decorative_only = _factual_weather_truth("❄️ Самые прохладные ночи")
+    assert decorative_only["snow"] is False
+    assert decorative_only["actual_precipitation"] is False
+    editorial_only = _factual_weather_truth(
+        "💬 Настрой на завтра: лучше оставить расписанию немного места для дождевого окна."
+    )
+    assert editorial_only["rain"] is False
+    assert editorial_only["actual_precipitation"] is False
+
+    positive_structured_icon = _factual_weather_truth(
+        "Калининград: 23/15 °C • ❄ • облачно"
+    )
+    assert positive_structured_icon["snow"] is False
+    explicit_word = _factual_weather_truth(
+        "Калининград: 1/-2 °C • снег"
+    )
+    assert explicit_word["snow"] is True
+
+
+def local_cover_semantic_validation_blocks_tampering() -> None:
+    with TemporaryDirectory() as tmp:
+        path = Path(tmp) / "cover.png"
+        metadata = render_kld_informative_cover(
+            MESSAGE,
+            post_type="evening",
+            visibility_context={
+                "visibility_condition": "reduced_visibility",
+                "morning_min_visibility_m": 5500,
+                "reported_visibility_threshold_m": 6000,
+            },
+            output_path=path,
+        )
+        valid = validate_kld_cover_semantics(
+            MESSAGE,
+            metadata,
+            post_type="evening",
+            visibility_context={
+                "visibility_condition": "reduced_visibility",
+                "morning_min_visibility_m": 5500,
+                "reported_visibility_threshold_m": 6000,
+            },
+        )
+        assert valid["valid"] is True, valid
+        tampered = json.loads(json.dumps(metadata, ensure_ascii=False))
+        tampered["facts"][0] = "СНЕГ МЕСТАМИ"
+        tampered["weather"]["snow"] = True
+        invalid = validate_kld_cover_semantics(
+            MESSAGE,
+            tampered,
+            post_type="evening",
+            visibility_context={
+                "visibility_condition": "reduced_visibility",
+                "morning_min_visibility_m": 5500,
+                "reported_visibility_threshold_m": 6000,
+            },
+        )
+        assert invalid["valid"] is False
+        assert any("display facts" in error or "snow" in error for error in invalid["errors"])
+
+
+def invalid_local_cover_is_not_sent_and_text_remains_nonblocking() -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        events: list[str] = []
+        outcome = _run_delivery(
+            root,
+            generate=lambda **kwargs: (_ for _ in ()).throw(RuntimeError("provider down")),
+            evaluate=lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("dedup must not run")),
+            cover_renderer=_cover_renderer(events),
+            validate_cover=lambda *args, **kwargs: {
+                "valid": False,
+                "errors": ["display facts differ from source"],
+            },
+            send_photo=lambda *args, **kwargs: events.append("photo") or 999,
+            record=_record(events),
+        )
+        assert outcome["result"] == "failed_nonfatal"
+        assert outcome["error_type"] == "InvalidLocalCover"
+        assert outcome["telegram_image_sent"] is False
+        assert outcome["local_cover_published"] is False
+        assert events == ["cover"]
+        final, order = _orchestrate(root, outcome)
+        assert final["text_sent"] is True
+        assert order == ["preview", "image", "text"]
+
+
+def second_backend_runs_after_pollinations_exhaustion_with_diagnostics() -> None:
+    class ProviderFailure(RuntimeError):
+        backend = "pollinations"
+        reason = "provider_failure"
+        attempts = [
+            {"attempt": 1, "http_status": 500, "exception_type": "HTTPError"},
+            {"attempt": 2, "http_status": None, "exception_type": "TimeoutError"},
+            {"attempt": 3, "http_status": 502, "exception_type": "HTTPError"},
+        ]
+
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        events: list[str] = []
+        outcome = _run_delivery(
+            root,
+            generate=lambda **kwargs: (_ for _ in ()).throw(ProviderFailure("Pollinations exhausted")),
+            secondary_generate=lambda **kwargs: _image(root / "horde.png", (55, 95, 145)),
+            provider_diagnostics=lambda backend: {
+                "backend": backend,
+                "http_attempt_count": 4,
+                "attempts": [
+                    {"attempt": 1, "stage": "submit", "http_status": 202},
+                    {"attempt": 2, "stage": "check", "http_status": 200},
+                    {"attempt": 3, "stage": "status", "http_status": 200},
+                    {"attempt": 4, "stage": "image_download", "http_status": 200},
+                ],
+            },
+            evaluate=lambda *args, **kwargs: _duplicate(accepted=True, reason="accepted", distance=22),
+            cover_renderer=_cover_renderer(events),
+            send_photo=lambda *args, **kwargs: events.append("photo") or 105,
+            record=_record(events),
+        )
+        assert outcome["backend"] == "stable_horde"
+        assert outcome["telegram_image_sent"] is True
+        assert outcome["cover_attempted"] is False
+        assert [item["backend"] for item in outcome["provider_attempts"]] == [
+            "pollinations",
+            "stable_horde",
+        ]
+        assert outcome["provider_attempts"][0]["http_attempt_count"] == 3
+        assert outcome["provider_attempts"][1]["http_attempt_count"] == 4
+        assert (
+            outcome["provider_attempts"][0]["scene_family"]
+            != outcome["provider_attempts"][1]["scene_family"]
+        )
+        assert (
+            outcome["provider_attempts"][0]["composition"]
+            != outcome["provider_attempts"][1]["composition"]
+        )
+        assert outcome["fallback_reason"] == "provider_failure"
+        assert outcome["http_attempt_count"] == 7
+        assert outcome["selected_scene_family"]
+        assert outcome["selected_composition"]
+        assert outcome["selected_cache_key"]
+        assert events == ["photo", "history"]
+
+
+def near_duplicate_candidates_are_hard_rejected_and_rotate_scene() -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        events: list[str] = []
+        generated = 0
+
+        def generate(**kwargs):
+            nonlocal generated
+            generated += 1
+            return _image(root / f"ai-{generated}.png", (70 + generated, 110, 140))
+
+        def evaluate(path, **kwargs):
+            if str(path).endswith("cover.png"):
+                return _duplicate(accepted=True, reason="accepted", distance=18)
+            return _duplicate(accepted=False, reason="near_duplicate", distance=3)
+
+        outcome = _run_delivery(
+            root,
+            generate=generate,
+            evaluate=evaluate,
+            cover_renderer=_cover_renderer(events),
+            send_photo=lambda *args, **kwargs: events.append("photo") or 106,
+            record=_record(events),
+        )
+        ai_attempts = [item for item in outcome["provider_attempts"] if item["backend"] == "pollinations"]
+        assert len(ai_attempts) == 3
+        assert len({item["scene_family"] for item in ai_attempts}) == 3
+        assert len({item["composition"] for item in ai_attempts}) == 3
+        assert all(item.get("dedup_reason") == "near_duplicate" for item in ai_attempts)
+        assert outcome["backend"] == "local_informative_cover"
+        assert outcome["fallback_reason"] == "near_duplicate"
+        assert outcome["local_cover_published"] is True
+        assert events == ["cover", "photo", "history"]
+
+
+def near_duplicate_local_cover_is_not_published() -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        events: list[str] = []
+        outcome = _run_delivery(
+            root,
+            generate=lambda **kwargs: (_ for _ in ()).throw(RuntimeError("provider down")),
+            evaluate=lambda *args, **kwargs: _duplicate(
+                accepted=False,
+                reason="near_duplicate",
+                distance=2,
+            ),
+            cover_renderer=_cover_renderer(events),
+            send_photo=lambda *args, **kwargs: events.append("photo") or 107,
+            record=_record(events),
+        )
+        assert outcome["result"] == "skipped_duplicate"
+        assert outcome["telegram_image_sent"] is False
+        assert outcome["local_cover_published"] is False
+        assert outcome["dedup_reason"] == "near_duplicate"
+        assert outcome["dedup_distance"] == 2
+        assert events == ["cover"]
+
+
+def recent_scene_and_composition_cooldown_is_applied() -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        history = [
+            {"scene_family": "wet_seaside_promenade", "composition": "wide diagonal shoreline composition"},
+            {"scene_family": "elevated_baltic_overlook", "composition": "pine-framed side composition"},
+            {"scene_family": "kaliningrad_urban_coastal_view", "composition": "open horizon with large sky"},
+        ]
+        (root / "history.json").write_text(json.dumps(history), encoding="utf-8")
+        events: list[str] = []
+        outcome = _run_delivery(
+            root,
+            generate=lambda **kwargs: _image(root / "ai.png"),
+            evaluate=lambda *args, **kwargs: _duplicate(accepted=True, reason="accepted", distance=20),
+            cover_renderer=_cover_renderer(events),
+            send_photo=lambda *args, **kwargs: events.append("photo") or 108,
+            record=_record(events),
+        )
+        selected = outcome["provider_attempts"][0]
+        assert selected["scene_family"] not in outcome["scene_cooldown"]
+        assert selected["composition"] not in outcome["composition_cooldown"]
+        assert len(outcome["scene_cooldown"]) == 3
+        assert len(outcome["composition_cooldown"]) == 3
+
+
+def pollinations_exception_retains_all_http_attempts() -> None:
+    original_http_get = imagegen._http_get
+    original_sleep = imagegen.time.sleep
+    calls = 0
+
+    def fail_http(url: str, *, timeout: float):
+        nonlocal calls
+        calls += 1
+        raise TimeoutError(f"offline timeout {calls}")
+
+    try:
+        imagegen._http_get = fail_http
+        imagegen.time.sleep = lambda seconds: None
+        with TemporaryDirectory() as tmp:
+            try:
+                imagegen.download_image_to_file(
+                    "https://example.invalid/image",
+                    Path(tmp) / "image.jpg",
+                    retries=3,
+                    backend="pollinations",
+                )
+            except imagegen.ImageGenerationError as exc:
+                assert exc.backend == "pollinations"
+                assert exc.reason == "provider_failure"
+                assert len(exc.attempts) == 3
+                assert all(item["exception_type"] == "TimeoutError" for item in exc.attempts)
+            else:
+                raise AssertionError("provider failure must retain structured attempts")
+        diagnostics = imagegen.get_generation_diagnostics("pollinations")
+        assert diagnostics["http_attempt_count"] == 3
+        assert diagnostics["result"] == "failed"
+    finally:
+        imagegen._http_get = original_http_get
+        imagegen.time.sleep = original_sleep
+
+
+def invalid_provider_payload_is_classified_and_never_saved() -> None:
+    original_http_get = imagegen._http_get
+    original_sleep = imagegen.time.sleep
+    try:
+        imagegen._http_get = lambda url, timeout: (b"<html>not an image</html>" * 20, "text/html")
+        imagegen.time.sleep = lambda seconds: None
+        with TemporaryDirectory() as tmp:
+            output = Path(tmp) / "bad.jpg"
+            try:
+                imagegen.download_image_to_file(
+                    "https://example.invalid/image",
+                    output,
+                    retries=2,
+                    backend="pollinations",
+                )
+            except imagegen.ImageGenerationError as exc:
+                assert exc.reason == "invalid_image"
+                assert len(exc.attempts) == 2
+                assert all(item["exception_type"] == "ValueError" for item in exc.attempts)
+            else:
+                raise AssertionError("non-image provider payload must be rejected")
+            assert not output.exists()
+        diagnostics = imagegen.get_generation_diagnostics("pollinations")
+        assert diagnostics["reason"] == "invalid_image"
+    finally:
+        imagegen._http_get = original_http_get
+        imagegen.time.sleep = original_sleep
+
+
+def stable_horde_backend_has_offline_success_and_url_safety() -> None:
+    from PIL import Image
+
+    payload_buffer = io.BytesIO()
+    Image.new("RGB", (256, 256), (70, 100, 150)).save(payload_buffer, format="PNG")
+    encoded = base64.b64encode(payload_buffer.getvalue()).decode("ascii")
+    original_json_request = imagegen._horde_json_request
+    original_enabled = os.environ.get("KLD_STABLE_HORDE_ENABLED")
+
+    def fake_json_request(url: str, *, attempts, stage: str, **kwargs):
+        attempts.append(
+            {
+                "attempt": len(attempts) + 1,
+                "stage": stage,
+                "http_status": 200 if stage != "submit" else 202,
+                "exception_type": "",
+                "message": "",
+            }
+        )
+        if stage == "submit":
+            return {"id": "offline-job"}
+        if stage == "check":
+            return {"done": True}
+        return {"generations": [{"img": encoded}]}
+
+    try:
+        os.environ["KLD_STABLE_HORDE_ENABLED"] = "1"
+        imagegen._horde_json_request = fake_json_request
+        with TemporaryDirectory() as tmp:
+            output = imagegen.generate_kld_stable_horde_image(
+                prompt="offline Baltic coast",
+                style_name="test",
+                seed=123,
+                out_path=str(Path(tmp) / "horde.jpg"),
+            )
+            with Image.open(output) as rendered:
+                assert rendered.size == (256, 256)
+                assert rendered.format == "JPEG"
+        diagnostics = imagegen.get_generation_diagnostics("stable_horde")
+        assert diagnostics["result"] == "success"
+        assert diagnostics["http_attempt_count"] == 3
+        assert imagegen._public_horde_image_url("http://127.0.0.1/image.png") is False
+        assert imagegen._public_horde_image_url("http://localhost/image.png") is False
+    finally:
+        imagegen._horde_json_request = original_json_request
+        if original_enabled is None:
+            os.environ.pop("KLD_STABLE_HORDE_ENABLED", None)
+        else:
+            os.environ["KLD_STABLE_HORDE_ENABLED"] = original_enabled
+
+
 TESTS = [
     pollinations_failure_uses_cover_and_text_once,
     exact_duplicates_are_nonfatal_and_text_once,
@@ -1095,6 +1490,16 @@ TESTS = [
     storm_and_thunderstorm_flags_drive_graphics_independently,
     storm_badge_uses_word_or_gust_threshold_not_strong_wind,
     mixed_regional_precipitation_keeps_text_and_graphics_aligned,
+    production_decorative_snow_headers_are_not_weather_evidence,
+    local_cover_semantic_validation_blocks_tampering,
+    invalid_local_cover_is_not_sent_and_text_remains_nonblocking,
+    second_backend_runs_after_pollinations_exhaustion_with_diagnostics,
+    near_duplicate_candidates_are_hard_rejected_and_rotate_scene,
+    near_duplicate_local_cover_is_not_published,
+    recent_scene_and_composition_cooldown_is_applied,
+    pollinations_exception_retains_all_http_attempts,
+    invalid_provider_payload_is_classified_and_never_saved,
+    stable_horde_backend_has_offline_success_and_url_safety,
 ]
 
 

--- a/tools/test_kld_visual_workflow.py
+++ b/tools/test_kld_visual_workflow.py
@@ -127,6 +127,20 @@ def test_image_failure_is_nonblocking_and_diagnostics_are_always_uploaded() -> N
     _assert("text_failure_reraised", "text_error_type" in helper and "raise\n" in helper)
     _assert("expected_duplicate_not_system_exit", "only exact duplicate candidates; refusing to send" not in image_tool)
     _assert("structured_result", '"fallback_sent"' in image_tool and '"failed_nonfatal"' in image_tool)
+    for field in (
+        '"http_attempt_count"',
+        '"selected_scene_family"',
+        '"selected_composition"',
+        '"selected_cache_key"',
+        '"dedup_reason"',
+        '"dedup_distance"',
+        '"local_cover_published"',
+        '"cover_validation"',
+    ):
+        _assert(f"structured_diagnostics_{field}", field in image_tool)
+    _assert("stable_horde_second_backend", "generate_kld_stable_horde_image" in image_tool)
+    _assert("semantic_cover_gate", "validate_kld_cover_semantics" in image_tool)
+    _assert("near_duplicate_not_promoted", "least_similar" not in image_tool)
 
     for name, block in (("morning", morning), ("evening", evening)):
         _assert(f"{name}_artifact_always", "if: always()" in block)

--- a/tools/test_visual_kld.py
+++ b/tools/test_visual_kld.py
@@ -1117,6 +1117,21 @@ def run_controlled_variety_cases() -> None:
 
 def run_scene_family_rotation_cases() -> None:
     name = "scene_family_rotation"
+    required_categories = {
+        "zelenogradsk_promenade",
+        "baltiysk_breakwater",
+        "svetlogorsk_cliff_coast",
+        "pine_forest_sea_path",
+        "quiet_lagoon_coast",
+        "kaliningrad_urban_coastal_view",
+        "curonian_spit_dunes",
+        "rainy_coastal_road",
+    }
+    if not required_categories.issubset(set(KLD_SCENE_FAMILIES)):
+        raise AssertionError(
+            f"{name}: scene catalogue is missing categories "
+            f"{sorted(required_categories - set(KLD_SCENE_FAMILIES))}"
+        )
     message = CASES[0]["message"]
     scene_families: list[str] = []
     for day in range(7):
@@ -1139,6 +1154,9 @@ def run_scene_family_rotation_cases() -> None:
         )
         morning_scene = morning_meta["scene_family"]
         evening_scene = evening_meta["scene_family"]
+        for scene in (morning_scene, evening_scene):
+            if scene in {"stormy_open_baltic", "wet_seaside_promenade", "rainy_coastal_road"}:
+                raise AssertionError(f"{name}: cloudy fixture selected contradictory scene {scene}")
         if morning_scene == evening_scene:
             raise AssertionError(f"{name}: morning/evening scene repeated for {date_value}: {morning_scene}")
         if scene_families and morning_scene == scene_families[-1]:


### PR DESCRIPTION
## Root cause and production evidence

Reviewed Telegram export `photo_150`–`photo_161` and the available GitHub Actions diagnostics for 17–24 July 2026.

- 5/12 production images used the local informative cover.
- All five fallbacks were confirmed as Pollinations provider exhaustion after 3 HTTP attempts; none was caused by exact duplicate or invalid-image rejection.
- Four runs ended with `500 → timeout → 500`; one ended with `500 → 502 → 502`.
- Three local covers were nevertheless published with near-duplicate distances 1, 4, and 1.
- False snow came from the decorative heading `❄️ Самые прохладные ночи`, because a bare snow icon was treated as precipitation evidence.

## Changes

- Separate decorative headings from factual weather evidence; a bare `❄` is accepted only in a plausible structured cold-weather row, while explicit `снег/снежный` remains evidence.
- Add source-evidence traces and semantic validation before a local cover can be sent.
- Add structured provider diagnostics to `image_result.json`: backend, fallback reason, exception/HTTP attempts, scene, composition, cache key, dedup reason/distance, and local-cover publication state.
- Use a bounded fallback ladder: Pollinations retries → free AI Horde/Stable Horde (anonymous or explicitly configured key) → semantically validated local cover → text only.
- Reject both AI and local near-duplicates; remove the former “least similar rejected candidate” promotion.
- Rotate scene family and composition after rejection, with recent-history cooldown. Add urban coastal and rainy-road scene families and prevent storm/wet scenes from leaking into ordinary cloudy/clear scenarios.
- Reject non-image HTTP payloads before they can reach Telegram.

## Production replay (offline, no providers/Telegram)

All 12 exported messages were replayed through the corrected parser/renderer and passed semantic validation.

| Target | Corrected local-cover fact |
|---|---|
| 21.07 | `ДОЖДЬ МЕСТАМИ` |
| 24.07 | `МОРОСЬ МЕСТАМИ` |
| 25.07 | no precipitation/snow fact |

The archived 22.07 input itself contains the literal legacy line `Штормовое предупреждение` from before the already-published storm/gust fix. Current regressions still prove that weak 9 m/s wind alone does not create a storm warning.

External review artifacts (not committed): a 12-case CSV/Markdown table, corrected cover previews, and a contact sheet.

## Exact diff

7 files changed: 1,411 insertions, 116 deletions.

- `image_prompt_kld.py`
- `imagegen.py`
- `kld_informative_cover.py`
- `tools/kld_visual_fixture_image.py`
- `tools/test_kld_image_first.py`
- `tools/test_kld_visual_workflow.py`
- `tools/test_visual_kld.py`

No data files, generated images, caches, secrets, workflows, schedules, Telegram routing, Schumann/Safecast files, or production text editor files are included.

## Validation

- 220 automated offline checks across 15 test commands: all passed.
- 12/12 production-message replays: semantically valid.
- `python -m compileall -q .`: passed.
- Sequential `py_compile`: 52 tracked Python files passed.
- YAML parsing: 10 workflow files passed.
- `git diff --check`: passed.
- Working tree clean after commit.
