### PR TITLE
fix: keep KLD summer vegetation green

### DIFF
--- a/image_prompt_kld_morning.py
+++ b/image_prompt_kld_morning.py
@@ -173,6 +173,18 @@ def _sanitize_morning_prompt(
     return final_prompt + "\n" + _SCENIC_ONLY_GUARD
 
 
+def _extract_message_date_key(text: str, fallback: dt.date | None = None) -> str:
+    """Extract the forecast date without depending on the main visual pipeline."""
+    value = str(text or "")
+    match = re.search(r"\b(\d{2})[./-](\d{2})[./-](\d{4})\b", value)
+    if match:
+        return f"{match.group(3)}-{match.group(2)}-{match.group(1)}"
+    match = re.search(r"\b(\d{4})-(\d{2})-(\d{2})\b", value)
+    if match:
+        return match.group(0)
+    return fallback.isoformat() if fallback else "undated"
+
+
 def _apply_summer_vegetation_guard(prompt: str, date_key: str) -> str:
     """Keep June-August KLD vegetation green and moisture-rich.
 
@@ -199,6 +211,7 @@ def build_kld_morning_prompt(
     visibility_context: object | None = None,
 ) -> Tuple[str, str]:
     """Build a deterministic morning prompt from the final FORMAT_V2 message."""
+    date_key = _extract_message_date_key(final_format_v2_message, dt.date.today())
     try:
         from visual_context_kld import build_visual_context
         from visual_rules import apply_visual_rules, build_prompt_from_cues
@@ -218,9 +231,8 @@ def build_kld_morning_prompt(
             weather_main=getattr(ctx, "weather_main", ""),
             visibility_condition=getattr(ctx, "visibility_condition", "clear"),
         )
-        from image_prompt_kld import _extract_prompt_date, _format_v2_style_name, apply_kld_controlled_variety
+        from image_prompt_kld import _format_v2_style_name, apply_kld_controlled_variety
 
-        date_key = _extract_prompt_date(final_format_v2_message, dt.date.today())
         prompt = apply_kld_controlled_variety(
             prompt,
             ctx,
@@ -241,7 +253,7 @@ def build_kld_morning_prompt(
     except Exception:
         logger.exception("KLD morning visual pipeline failed; using simple coastal fallback")
         fallback = _sanitize_morning_prompt(_fallback_morning_prompt())
-        fallback = _apply_summer_vegetation_guard(fallback, dt.date.today().isoformat())
+        fallback = _apply_summer_vegetation_guard(fallback, date_key)
         return fallback, "format_v2_scene_cues_morning"
 
 

--- a/image_prompt_kld_morning.py
+++ b/image_prompt_kld_morning.py
@@ -59,6 +59,13 @@ _CLOUDY_DRIZZLE_SAFE_BLOCK = (
     "quiet dunes and pines; fresh practical morning weather mood."
 )
 
+_SUMMER_VEGETATION_MONTHS = frozenset({6, 7, 8})
+_SUMMER_VEGETATION_CUE = (
+    "Summer vegetation adherence: humid Baltic summer vegetation is lush and fresh; "
+    "coastal grass and dune vegetation are visibly natural green across the foreground and midground; "
+    "shrubs and pines are healthy green; pale beige tones belong to sand, not to living vegetation."
+)
+
 _VISIBILITY_MORNING_CUES = {
     "dense_fog": (
         "Morning visibility adherence: dense humid fog; heavily reduced distant visibility; "
@@ -166,6 +173,24 @@ def _sanitize_morning_prompt(
     return final_prompt + "\n" + _SCENIC_ONLY_GUARD
 
 
+def _apply_summer_vegetation_guard(prompt: str, date_key: str) -> str:
+    """Keep June-August KLD vegetation green and moisture-rich.
+
+    The Baltic/Kaliningrad summer scene should not drift toward a dry steppe or
+    Mediterranean dune palette.  Keep this as a positive cue because image
+    generators can turn negative prompt words into visible objects.
+    """
+    try:
+        target_date = dt.date.fromisoformat(str(date_key)[:10])
+    except Exception:
+        return prompt
+    if target_date.month not in _SUMMER_VEGETATION_MONTHS:
+        return prompt
+    if _SUMMER_VEGETATION_CUE in str(prompt or ""):
+        return prompt
+    return str(prompt or "").rstrip() + "\n" + _SUMMER_VEGETATION_CUE
+
+
 def build_kld_morning_prompt(
     final_format_v2_message: str,
     *,
@@ -204,6 +229,7 @@ def build_kld_morning_prompt(
             source_text=final_format_v2_message,
             variation_attempt=variation_attempt,
         )
+        prompt = _apply_summer_vegetation_guard(prompt, date_key)
         style_name = _format_v2_style_name(
             ctx,
             date_key=date_key,
@@ -214,7 +240,9 @@ def build_kld_morning_prompt(
         return prompt, "format_v2_scene_cues_morning_" + style_name.rsplit("_", 1)[-1]
     except Exception:
         logger.exception("KLD morning visual pipeline failed; using simple coastal fallback")
-        return _sanitize_morning_prompt(_fallback_morning_prompt()), "format_v2_scene_cues_morning"
+        fallback = _sanitize_morning_prompt(_fallback_morning_prompt())
+        fallback = _apply_summer_vegetation_guard(fallback, dt.date.today().isoformat())
+        return fallback, "format_v2_scene_cues_morning"
 
 
 __all__ = ["build_kld_morning_prompt"]

--- a/tools/test_kld_summer_vegetation_prompt.py
+++ b/tools/test_kld_summer_vegetation_prompt.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Regression checks for green KLD summer vegetation in morning prompts."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from image_prompt_kld_morning import (  # noqa: E402
+    _SUMMER_VEGETATION_CUE,
+    _apply_summer_vegetation_guard,
+    build_kld_morning_prompt,
+)
+
+
+def august_production_like_prompt_requires_green_vegetation() -> None:
+    message = "\n".join(
+        [
+            "🌅 Калининград сегодня (01.08.2026)",
+            "🌊 Морские города",
+            "Светлогорск: 20/16 °C • 🌥 пасм • 🌊 18",
+            "Зеленоградск: 21/16 °C • 🌥 пасм • 🌊 18",
+            "💨 Ветер: 2.5 м/с, порывы до 6 м/с",
+            "🌫 Видимость: хорошая",
+        ]
+    )
+    prompt, style_name = build_kld_morning_prompt(message)
+    assert style_name.startswith("format_v2_scene_cues_morning_")
+    assert _SUMMER_VEGETATION_CUE in prompt
+    assert "coastal grass and dune vegetation are visibly natural green" in prompt
+    assert "pale beige tones belong to sand, not to living vegetation" in prompt
+
+
+def summer_guard_is_idempotent() -> None:
+    once = _apply_summer_vegetation_guard("base", "2026-08-01")
+    twice = _apply_summer_vegetation_guard(once, "2026-08-01")
+    assert once == twice
+    assert twice.count(_SUMMER_VEGETATION_CUE) == 1
+
+
+def non_summer_date_is_unchanged() -> None:
+    original = "base prompt"
+    assert _apply_summer_vegetation_guard(original, "2026-11-01") == original
+
+
+def malformed_date_is_unchanged() -> None:
+    original = "base prompt"
+    assert _apply_summer_vegetation_guard(original, "undated") == original
+
+
+def main() -> None:
+    checks = (
+        august_production_like_prompt_requires_green_vegetation,
+        summer_guard_is_idempotent,
+        non_summer_date_is_unchanged,
+        malformed_date_is_unchanged,
+    )
+    for check in checks:
+        check()
+        print(f"PASS: {check.__name__}")
+    print(f"OK: {len(checks)} KLD summer vegetation prompt checks passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Production issue

The 2026-08-01 morning KLD image rendered broad dry/golden grass. For summer Kaliningrad this is the wrong visual language for the channel: living coastal vegetation should read as fresh green, while beige tones belong to sand.

## Change

- add a June-August positive vegetation adherence cue to the final KLD morning prompt;
- keep the rule seasonal so autumn/winter prompts are unchanged;
- append the cue after controlled scene variety so generic `dune grass` wording cannot dominate it;
- use positive prompt language rather than a long negative list, because provider models can render forbidden words as objects;
- cover the 01.08.2026 production-like prompt, idempotency, non-summer dates and malformed dates with a focused offline regression test.

No workflows, Telegram calls, provider calls, data files or secrets are changed.