### PR TITLE
fix: explain KLD FX moves in plain Russian

### DIFF
--- a/post_kld_fx_market_pulse.py
+++ b/post_kld_fx_market_pulse.py
@@ -31,6 +31,12 @@ from post_kld import (
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
+_CURRENCY_RU = {
+    "USD": "доллар",
+    "EUR": "евро",
+    "CNY": "юань",
+}
+
 
 def _to_float(x: Any) -> float | None:
     try:
@@ -57,6 +63,66 @@ def _fmt_pct(value: float | None) -> str:
     if value < 0:
         return f" ↓{abs(value):.1f}%"
     return " →0.0%"
+
+
+def _join_ru(items: list[str]) -> str:
+    if not items:
+        return ""
+    if len(items) == 1:
+        return items[0]
+    if len(items) == 2:
+        return f"{items[0]} и {items[1]}"
+    return ", ".join(items[:-1]) + f" и {items[-1]}"
+
+
+def build_plain_ruble_summary(rates: dict[str, Any]) -> str | None:
+    """Explain CBR deltas in everyday Russian instead of market jargon.
+
+    Positive delta means one unit of the foreign currency costs more rubles than
+    in the previous CBR rate; negative delta means it costs fewer rubles.
+    """
+    cheaper: list[str] = []
+    dearer: list[str] = []
+    unchanged: list[str] = []
+
+    for code in ("USD", "EUR", "CNY"):
+        delta = _to_float((rates.get(code) or {}).get("delta"))
+        if delta is None:
+            continue
+        label = _CURRENCY_RU[code]
+        if delta < 0:
+            cheaper.append(label)
+        elif delta > 0:
+            dearer.append(label)
+        else:
+            unchanged.append(label)
+
+    parts: list[str] = []
+    if cheaper:
+        parts.append(f"{_join_ru(cheaper)} — дешевле")
+    if dearer:
+        parts.append(f"{_join_ru(dearer)} — дороже")
+    if unchanged:
+        parts.append(f"{_join_ru(unchanged)} — без изменений")
+    if not parts:
+        return None
+
+    return "🧭 Проще: по сравнению с прошлым курсом ЦБ " + ", ".join(parts) + "."
+
+
+def apply_plain_ruble_summary(fx_text: str, rates: dict[str, Any]) -> str:
+    summary = build_plain_ruble_summary(rates)
+    if not summary:
+        return fx_text
+
+    lines = str(fx_text or "").splitlines()
+    for index, line in enumerate(lines):
+        if line.strip().startswith("🧭"):
+            lines[index] = summary
+            return "\n".join(lines)
+    if not lines:
+        return summary
+    return str(fx_text).rstrip() + "\n" + summary
 
 
 def _fetch_crypto() -> list[str]:
@@ -212,6 +278,7 @@ async def main() -> None:
     tz = pendulum.timezone(TZ_STR)
     date_local = pendulum.parse(args.date).in_tz(tz) if args.date else pendulum.now(tz)
     fx_text, rates = _build_fx_message(date_local, tz)
+    fx_text = apply_plain_ruble_summary(fx_text, rates)
     text = inject_market_pulse(fx_text, build_market_pulse_block())
     raw_date = rates.get("as_of") or rates.get("date") or rates.get("cbr_date")
     cbr_date = _normalize_cbr_date(raw_date)

--- a/tools/test_kld_fx_plain_language.py
+++ b/tools/test_kld_fx_plain_language.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Focused checks for plain-language KLD FX movement summaries."""
+from __future__ import annotations
+
+import os
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("TELEGRAM_TOKEN_KLG", "test-token")
+
+telegram = types.ModuleType("telegram")
+telegram.Bot = object
+telegram.constants = types.SimpleNamespace(ParseMode=types.SimpleNamespace(HTML="HTML"))
+sys.modules.setdefault("telegram", telegram)
+
+pendulum = types.ModuleType("pendulum")
+pendulum.DateTime = object
+pendulum.Timezone = object
+sys.modules.setdefault("pendulum", pendulum)
+
+post_common = types.ModuleType("post_common")
+post_common.build_message = lambda *args, **kwargs: ""
+post_common.fx_morning_line = lambda *args, **kwargs: None
+sys.modules.setdefault("post_common", post_common)
+
+import post_kld_fx_market_pulse as pulse  # noqa: E402
+
+
+def mixed_production_case_is_explained_plainly() -> None:
+    rates = {
+        "USD": {"delta": -0.39},
+        "EUR": {"delta": 0.31},
+        "CNY": {"delta": -0.05},
+    }
+    summary = pulse.build_plain_ruble_summary(rates)
+    assert summary == (
+        "🧭 Проще: по сравнению с прошлым курсом ЦБ "
+        "доллар и юань — дешевле, евро — дороже."
+    )
+
+
+def all_dearer_is_grouped() -> None:
+    rates = {
+        "USD": {"delta": 0.10},
+        "EUR": {"delta": 0.20},
+        "CNY": {"delta": 0.03},
+    }
+    assert pulse.build_plain_ruble_summary(rates) == (
+        "🧭 Проще: по сравнению с прошлым курсом ЦБ доллар, евро и юань — дороже."
+    )
+
+
+def all_cheaper_is_grouped() -> None:
+    rates = {
+        "USD": {"delta": -0.10},
+        "EUR": {"delta": -0.20},
+        "CNY": {"delta": -0.03},
+    }
+    assert pulse.build_plain_ruble_summary(rates) == (
+        "🧭 Проще: по сравнению с прошлым курсом ЦБ доллар, евро и юань — дешевле."
+    )
+
+
+def zero_delta_is_explained() -> None:
+    rates = {
+        "USD": {"delta": 0},
+        "EUR": {"delta": 0.20},
+        "CNY": {"delta": -0.03},
+    }
+    assert pulse.build_plain_ruble_summary(rates) == (
+        "🧭 Проще: по сравнению с прошлым курсом ЦБ юань — дешевле, "
+        "евро — дороже, доллар — без изменений."
+    )
+
+
+def existing_navigation_line_is_replaced() -> None:
+    fx_text = "\n".join(
+        [
+            "💱 <b>Курсы ЦБ РФ на 01.08</b>",
+            "USD 79.46 ₽ ↓0.39 · EUR 91.19 ₽ ↑0.31 · CNY 11.77 ₽ ↓0.05",
+            "🧭 Валюты к ₽ движутся смешанно.",
+        ]
+    )
+    rates = {
+        "USD": {"delta": -0.39},
+        "EUR": {"delta": 0.31},
+        "CNY": {"delta": -0.05},
+    }
+    text = pulse.apply_plain_ruble_summary(fx_text, rates)
+    assert "Валюты к ₽ движутся смешанно" not in text
+    assert "доллар и юань — дешевле, евро — дороже" in text
+    assert text.count("🧭") == 1
+
+
+def missing_deltas_leave_text_unchanged() -> None:
+    fx_text = "💱 Курсы\n🧭 Валюты к ₽ движутся смешанно."
+    assert pulse.apply_plain_ruble_summary(fx_text, {}) == fx_text
+
+
+def main() -> None:
+    checks = (
+        mixed_production_case_is_explained_plainly,
+        all_dearer_is_grouped,
+        all_cheaper_is_grouped,
+        zero_delta_is_explained,
+        existing_navigation_line_is_replaced,
+        missing_deltas_leave_text_unchanged,
+    )
+    for check in checks:
+        check()
+        print(f"PASS: {check.__name__}")
+    print(f"OK: {len(checks)} KLD FX plain-language checks passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

The noon KLD FX post currently ends with market-style wording such as `Валюты к ₽ движутся смешанно`, which is technically correct but not useful to a general reader.

## Change

- keep the existing CBR numbers and arrows unchanged;
- translate USD/EUR/CNY deltas into everyday Russian in the production noon runner;
- example for the 01.08 case: `🧭 Проще: по сравнению с прошлым курсом ЦБ доллар и юань — дешевле, евро — дороже.`;
- group all-up/all-down cases naturally;
- explain zero movement as `без изменений`;
- leave the original text untouched if usable deltas are unavailable.

The data source, anti-duplicate cache, Market Pulse fetches, workflows, Telegram routing and publication cadence are unchanged.

Adds focused offline regression coverage for mixed, all-up, all-down, zero and missing-delta cases.