### PR TITLE
fix: explain KLD ruble moves in plain Russian

### DIFF
--- a/post_kld_fx_market_pulse.py
+++ b/post_kld_fx_market_pulse.py
@@ -66,19 +66,8 @@ def _fmt_pct(value: float | None) -> str:
     return " →0.0%"
 
 
-def _fmt_ruble_change_amount(delta: float) -> str:
-    """Format a CBR day-to-day move for ordinary readers."""
-    value = abs(float(delta))
-    if value < 1:
-        kopecks = int(round(value * 100))
-        if kopecks <= 0:
-            return "меньше 1 коп."
-        return f"{kopecks} коп."
-    return f"{value:.2f}".replace(".", ",") + " ₽"
-
-
 def build_plain_ruble_summary(rates: dict[str, Any]) -> str:
-    """Explain each available RUB move without trading jargon."""
+    """Explain each available RUB move without repeating the numbers above."""
     parts: list[str] = []
     for code in _CURRENCY_ORDER:
         delta = _to_float((rates.get(code) or {}).get("delta"))
@@ -86,11 +75,11 @@ def build_plain_ruble_summary(rates: dict[str, Any]) -> str:
             continue
         name = _CURRENCY_NAMES_RU[code]
         if abs(delta) < 0.005:
-            parts.append(f"{name} почти не изменился")
+            parts.append(f"курс {name} почти не изменился")
         elif delta > 0:
-            parts.append(f"{name} подорожал на {_fmt_ruble_change_amount(delta)}")
+            parts.append(f"{name} подорожал")
         else:
-            parts.append(f"{name} подешевел на {_fmt_ruble_change_amount(delta)}")
+            parts.append(f"{name} подешевел")
     if not parts:
         return ""
     return "🧭 К рублю: " + ", ".join(parts) + "."

--- a/post_kld_fx_market_pulse.py
+++ b/post_kld_fx_market_pulse.py
@@ -31,6 +31,13 @@ from post_kld import (
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
+_CURRENCY_NAMES_RU = {
+    "USD": "доллар",
+    "EUR": "евро",
+    "CNY": "юань",
+}
+_CURRENCY_ORDER = ("USD", "EUR", "CNY")
+
 
 def _to_float(x: Any) -> float | None:
     try:
@@ -57,6 +64,53 @@ def _fmt_pct(value: float | None) -> str:
     if value < 0:
         return f" ↓{abs(value):.1f}%"
     return " →0.0%"
+
+
+def _fmt_ruble_change_amount(delta: float) -> str:
+    """Format a CBR day-to-day move for ordinary readers."""
+    value = abs(float(delta))
+    if value < 1:
+        kopecks = int(round(value * 100))
+        if kopecks <= 0:
+            return "меньше 1 коп."
+        return f"{kopecks} коп."
+    return f"{value:.2f}".replace(".", ",") + " ₽"
+
+
+def build_plain_ruble_summary(rates: dict[str, Any]) -> str:
+    """Explain each available RUB move without trading jargon."""
+    parts: list[str] = []
+    for code in _CURRENCY_ORDER:
+        delta = _to_float((rates.get(code) or {}).get("delta"))
+        if delta is None:
+            continue
+        name = _CURRENCY_NAMES_RU[code]
+        if abs(delta) < 0.005:
+            parts.append(f"{name} почти не изменился")
+        elif delta > 0:
+            parts.append(f"{name} подорожал на {_fmt_ruble_change_amount(delta)}")
+        else:
+            parts.append(f"{name} подешевел на {_fmt_ruble_change_amount(delta)}")
+    if not parts:
+        return ""
+    return "🧭 К рублю: " + ", ".join(parts) + "."
+
+
+def replace_ruble_summary(fx_text: str, rates: dict[str, Any]) -> str:
+    """Replace the old aggregate summary with a concrete plain-language line."""
+    summary = build_plain_ruble_summary(rates)
+    if not summary:
+        return fx_text
+    lines = str(fx_text or "").splitlines()
+    replaced = False
+    for index, line in enumerate(lines):
+        if line.strip().startswith("🧭"):
+            lines[index] = summary
+            replaced = True
+            break
+    if not replaced:
+        lines.append(summary)
+    return "\n".join(lines)
 
 
 def _fetch_crypto() -> list[str]:
@@ -212,6 +266,7 @@ async def main() -> None:
     tz = pendulum.timezone(TZ_STR)
     date_local = pendulum.parse(args.date).in_tz(tz) if args.date else pendulum.now(tz)
     fx_text, rates = _build_fx_message(date_local, tz)
+    fx_text = replace_ruble_summary(fx_text, rates)
     text = inject_market_pulse(fx_text, build_market_pulse_block())
     raw_date = rates.get("as_of") or rates.get("date") or rates.get("cbr_date")
     cbr_date = _normalize_cbr_date(raw_date)

--- a/post_kld_fx_market_pulse.py
+++ b/post_kld_fx_market_pulse.py
@@ -75,7 +75,7 @@ def build_plain_ruble_summary(rates: dict[str, Any]) -> str:
             continue
         name = _CURRENCY_NAMES_RU[code]
         if abs(delta) < 0.005:
-            parts.append(f"курс {name} почти не изменился")
+            parts.append(f"{name} почти не изменился")
         elif delta > 0:
             parts.append(f"{name} подорожал")
         else:

--- a/tools/test_fx_market_pulse_kld.py
+++ b/tools/test_fx_market_pulse_kld.py
@@ -67,7 +67,7 @@ def kld_plain_summary_large_moves_still_avoids_duplicate_numbers() -> None:
 def kld_plain_summary_handles_zero_and_missing() -> None:
     rates = _rates(0.0, None, 0.004)
     summary = pulse.build_plain_ruble_summary(rates)
-    assert summary == "🧭 К рублю: курс доллар почти не изменился, курс юань почти не изменился."
+    assert summary == "🧭 К рублю: доллар почти не изменился, юань почти не изменился."
 
 
 def kld_plain_summary_is_appended_when_old_line_missing() -> None:

--- a/tools/test_fx_market_pulse_kld.py
+++ b/tools/test_fx_market_pulse_kld.py
@@ -33,41 +33,53 @@ import post_kld  # noqa: E402
 import post_kld_fx_market_pulse as pulse  # noqa: E402
 
 
-def kld_fx_message_uses_arrows_and_summary() -> None:
-    post_kld._load_fx_rates = lambda _date, _tz: {
-        "date": "2026-06-27",
-        "USD": {"value": 77.06, "delta": 1.43},
-        "EUR": {"value": 87.40, "delta": 1.63},
-        "CNY": {"value": 11.34, "delta": 0.29},
+def _rates(usd: float | None, eur: float | None, cny: float | None) -> dict:
+    return {
+        "date": "2026-08-01",
+        "USD": {"value": 79.46, "delta": usd},
+        "EUR": {"value": 91.19, "delta": eur},
+        "CNY": {"value": 11.77, "delta": cny},
     }
-    text, _rates = post_kld._build_fx_message(None, None)
-    assert "💱 <b>Курсы ЦБ РФ на 27.06</b>" in text
-    assert "USD 77.06 ₽ ↑1.43 · EUR 87.40 ₽ ↑1.63 · CNY 11.34 ₽ ↑0.29" in text
-    assert "🧭 Рубль слабее к USD, EUR и CNY." in text
-    assert "валюты подросли к ₽" not in text
-    assert "(" not in text and ")" not in text
 
 
-def kld_fx_summary_negative_is_stronger() -> None:
-    post_kld._load_fx_rates = lambda _date, _tz: {
-        "date": "2026-06-27",
-        "USD": {"value": 77.06, "delta": -1.43},
-        "EUR": {"value": 87.40, "delta": -1.63},
-        "CNY": {"value": 11.34, "delta": -0.29},
-    }
-    text, _rates = post_kld._build_fx_message(None, None)
-    assert "🧭 Рубль крепче к USD, EUR и CNY." in text
+def kld_fx_message_keeps_numeric_line() -> None:
+    post_kld._load_fx_rates = lambda _date, _tz: _rates(-0.39, 0.31, -0.05)
+    text, _rates_data = post_kld._build_fx_message(None, None)
+    assert "💱 <b>Курсы ЦБ РФ на 01.08</b>" in text
+    assert "USD 79.46 ₽ ↓0.39 · EUR 91.19 ₽ ↑0.31 · CNY 11.77 ₽ ↓0.05" in text
 
 
-def kld_fx_summary_mixed_is_mixed() -> None:
-    post_kld._load_fx_rates = lambda _date, _tz: {
-        "date": "2026-06-27",
-        "USD": {"value": 77.06, "delta": 1.43},
-        "EUR": {"value": 87.40, "delta": -1.63},
-        "CNY": {"value": 11.34, "delta": 0.29},
-    }
-    text, _rates = post_kld._build_fx_message(None, None)
-    assert "🧭 Валюты к ₽ движутся смешанно." in text
+def kld_plain_summary_explains_mixed_moves() -> None:
+    rates = _rates(-0.39, 0.31, -0.05)
+    raw = "💱 Курсы\nUSD/EUR/CNY\n🧭 Валюты к ₽ движутся смешанно."
+    text = pulse.replace_ruble_summary(raw, rates)
+    assert text.endswith(
+        "🧭 К рублю: доллар подешевел на 39 коп., евро подорожал на 31 коп., "
+        "юань подешевел на 5 коп."
+    )
+    assert "движутся смешанно" not in text
+    assert "Рубль слабее" not in text
+    assert "Рубль крепче" not in text
+
+
+def kld_plain_summary_uses_rubles_for_large_moves() -> None:
+    summary = pulse.build_plain_ruble_summary(_rates(1.43, -1.63, 0.29))
+    assert summary == (
+        "🧭 К рублю: доллар подорожал на 1,43 ₽, евро подешевел на 1,63 ₽, "
+        "юань подорожал на 29 коп."
+    )
+
+
+def kld_plain_summary_handles_zero_and_missing() -> None:
+    rates = _rates(0.0, None, 0.004)
+    summary = pulse.build_plain_ruble_summary(rates)
+    assert summary == "🧭 К рублю: доллар почти не изменился, юань почти не изменился."
+
+
+def kld_plain_summary_is_appended_when_old_line_missing() -> None:
+    rates = _rates(-0.39, 0.31, -0.05)
+    text = pulse.replace_ruble_summary("💱 Курсы\nUSD/EUR/CNY", rates)
+    assert text.count("🧭 К рублю:") == 1
 
 
 def kld_market_pulse_is_compact() -> None:
@@ -86,9 +98,11 @@ def kld_market_pulse_is_compact() -> None:
 
 def main() -> None:
     checks = (
-        kld_fx_message_uses_arrows_and_summary,
-        kld_fx_summary_negative_is_stronger,
-        kld_fx_summary_mixed_is_mixed,
+        kld_fx_message_keeps_numeric_line,
+        kld_plain_summary_explains_mixed_moves,
+        kld_plain_summary_uses_rubles_for_large_moves,
+        kld_plain_summary_handles_zero_and_missing,
+        kld_plain_summary_is_appended_when_old_line_missing,
         kld_market_pulse_is_compact,
     )
     for check in checks:

--- a/tools/test_fx_market_pulse_kld.py
+++ b/tools/test_fx_market_pulse_kld.py
@@ -49,31 +49,25 @@ def kld_fx_message_keeps_numeric_line() -> None:
     assert "USD 79.46 ₽ ↓0.39 · EUR 91.19 ₽ ↑0.31 · CNY 11.77 ₽ ↓0.05" in text
 
 
-def kld_plain_summary_explains_mixed_moves() -> None:
+def kld_plain_summary_explains_mixed_moves_without_repeating_numbers() -> None:
     rates = _rates(-0.39, 0.31, -0.05)
     raw = "💱 Курсы\nUSD/EUR/CNY\n🧭 Валюты к ₽ движутся смешанно."
     text = pulse.replace_ruble_summary(raw, rates)
-    assert text.endswith(
-        "🧭 К рублю: доллар подешевел на 39 коп., евро подорожал на 31 коп., "
-        "юань подешевел на 5 коп."
-    )
+    assert text.endswith("🧭 К рублю: доллар подешевел, евро подорожал, юань подешевел.")
     assert "движутся смешанно" not in text
-    assert "Рубль слабее" not in text
-    assert "Рубль крепче" not in text
+    assert "39 коп" not in text and "31 коп" not in text and "5 коп" not in text
 
 
-def kld_plain_summary_uses_rubles_for_large_moves() -> None:
+def kld_plain_summary_large_moves_still_avoids_duplicate_numbers() -> None:
     summary = pulse.build_plain_ruble_summary(_rates(1.43, -1.63, 0.29))
-    assert summary == (
-        "🧭 К рублю: доллар подорожал на 1,43 ₽, евро подешевел на 1,63 ₽, "
-        "юань подорожал на 29 коп."
-    )
+    assert summary == "🧭 К рублю: доллар подорожал, евро подешевел, юань подорожал."
+    assert "1,43" not in summary and "1,63" not in summary and "29 коп" not in summary
 
 
 def kld_plain_summary_handles_zero_and_missing() -> None:
     rates = _rates(0.0, None, 0.004)
     summary = pulse.build_plain_ruble_summary(rates)
-    assert summary == "🧭 К рублю: доллар почти не изменился, юань почти не изменился."
+    assert summary == "🧭 К рублю: курс доллар почти не изменился, курс юань почти не изменился."
 
 
 def kld_plain_summary_is_appended_when_old_line_missing() -> None:
@@ -99,8 +93,8 @@ def kld_market_pulse_is_compact() -> None:
 def main() -> None:
     checks = (
         kld_fx_message_keeps_numeric_line,
-        kld_plain_summary_explains_mixed_moves,
-        kld_plain_summary_uses_rubles_for_large_moves,
+        kld_plain_summary_explains_mixed_moves_without_repeating_numbers,
+        kld_plain_summary_large_moves_still_avoids_duplicate_numbers,
         kld_plain_summary_handles_zero_and_missing,
         kld_plain_summary_is_appended_when_old_line_missing,
         kld_market_pulse_is_compact,


### PR DESCRIPTION
## Problem

The published line `Валюты к ₽ движутся смешанно` is technically correct but not useful to an ordinary reader: it forces people to decode arrows and infer what changed.

## Change

- keep the existing numeric CBR line unchanged;
- replace the aggregate trading-style summary in the public noon FX + Market Pulse post with one concrete sentence per available currency;
- do not repeat numeric deltas because the exact values and arrows are already shown above;
- use plain verbs: `подорожал`, `подешевел`, `почти не изменился`;
- omit currencies with missing deltas;
- add focused offline coverage for mixed, large, flat/missing-data cases and summary insertion.

Example:

`🧭 К рублю: доллар подешевел, евро подорожал, юань подешевел.`

No workflows, Telegram calls, market requests, data files or secrets are changed.