### PR TITLE
fix: harden KLD FX summary edge case

### DIFF
--- a/post_kld_fx_market_pulse.py
+++ b/post_kld_fx_market_pulse.py
@@ -88,17 +88,14 @@ def build_plain_ruble_summary(rates: dict[str, Any]) -> str:
 def replace_ruble_summary(fx_text: str, rates: dict[str, Any]) -> str:
     """Replace the old aggregate summary with a concrete plain-language line."""
     summary = build_plain_ruble_summary(rates)
-    if not summary:
-        return fx_text
+    replacement = summary or "🧭 К рублю: динамика за день пока недоступна."
     lines = str(fx_text or "").splitlines()
-    replaced = False
     for index, line in enumerate(lines):
         if line.strip().startswith("🧭"):
-            lines[index] = summary
-            replaced = True
+            lines[index] = replacement
             break
-    if not replaced:
-        lines.append(summary)
+    else:
+        lines.append(replacement)
     return "\n".join(lines)
 
 

--- a/tools/test_fx_market_pulse_kld.py
+++ b/tools/test_fx_market_pulse_kld.py
@@ -70,6 +70,14 @@ def kld_plain_summary_handles_zero_and_missing() -> None:
     assert summary == "🧭 К рублю: доллар почти не изменился, юань почти не изменился."
 
 
+def kld_missing_deltas_never_restore_old_jargon() -> None:
+    rates = _rates(None, None, None)
+    raw = "💱 Курсы\nUSD/EUR/CNY\n🧭 Валюты к ₽ движутся смешанно."
+    text = pulse.replace_ruble_summary(raw, rates)
+    assert text.endswith("🧭 К рублю: динамика за день пока недоступна.")
+    assert "движутся смешанно" not in text
+
+
 def kld_plain_summary_is_appended_when_old_line_missing() -> None:
     rates = _rates(-0.39, 0.31, -0.05)
     text = pulse.replace_ruble_summary("💱 Курсы\nUSD/EUR/CNY", rates)
@@ -96,6 +104,7 @@ def main() -> None:
         kld_plain_summary_explains_mixed_moves_without_repeating_numbers,
         kld_plain_summary_large_moves_still_avoids_duplicate_numbers,
         kld_plain_summary_handles_zero_and_missing,
+        kld_missing_deltas_never_restore_old_jargon,
         kld_plain_summary_is_appended_when_old_line_missing,
         kld_market_pulse_is_compact,
     )


### PR DESCRIPTION
## Follow-up to PR #16

The human-readable ruble summary is now in `main`. This follow-up closes the same partial-data edge case already fixed for Cyprus.

## Fix

- if CBR has current USD/EUR/CNY values but no day-to-day deltas, never leave the old `Валюты к ₽ движутся смешанно` line in place;
- show `🧭 К рублю: динамика за день пока недоступна.` instead;
- keep the normal concise wording unchanged when deltas exist;
- add a focused regression test for the all-deltas-missing case.

No workflows, Telegram calls, market requests, data files or secrets are changed.