### PR TITLE
fix: harden KLD evening visual allocator

### DIFF
--- a/kld_visual_policy.py
+++ b/kld_visual_policy.py
@@ -22,8 +22,8 @@ SUMMER_VEGETATION_CUE = (
 )
 
 SCENE_NEUTRAL_PHOTO_CONTRACT = (
-    "Scene identity adherence: render one coherent real Kaliningrad-region scene chosen by the "
-    "selected scene family; preserve that scene family as the dominant geography; include only "
+    "Scene identity adherence: the selected scene family is authoritative; render one coherent real "
+    "Kaliningrad-region scene chosen by that family; preserve it as the dominant geography; include only "
     "landforms and objects naturally belonging to that scene; use realistic northern vegetation, "
     "weather and atmospheric perspective; ground-level or natural elevated photographic viewpoint."
 )

--- a/kld_visual_policy.py
+++ b/kld_visual_policy.py
@@ -167,12 +167,15 @@ def finalize_kld_provider_prompt(
     """Apply the final shared provider contract to morning/evening prompts.
 
     The upstream VisualRules layer still carries a legacy generic coast base
-    scene.  This finalizer removes that geography lock and any older controlled
+    scene. This finalizer removes that geography lock and any older controlled
     composition line, then inserts exactly one scene-authoritative contract.
     Provider/UI safety and summer vegetation are applied at the same final point
-    for both morning and evening delivery paths.
+    for both morning and evening delivery paths. Seasonal appearance follows
+    the visual target date (important for evening forecasts crossing a month).
     """
-    target = parse_date_key(date_key or metadata.get("target_date") or metadata.get("forecast_date"))
+    target = parse_date_key(
+        metadata.get("target_date") or date_key or metadata.get("forecast_date")
+    )
     summer = bool(target and target.month in SUMMER_MONTHS)
     out: list[str] = []
     for line in str(prompt or "").splitlines():

--- a/kld_visual_policy.py
+++ b/kld_visual_policy.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import datetime as dt
 from typing import Any, Mapping, Sequence
 
-KLD_VISUAL_POLICY_VERSION = "kld_visual_policy_v1"
+KLD_VISUAL_POLICY_VERSION = "kld_visual_policy_v2"
 SUMMER_MONTHS = frozenset({6, 7, 8})
 
 SUMMER_VEGETATION_CUE = (
@@ -40,6 +40,11 @@ _OPEN_BEACH_MACRO = frozenset(
         "yantarny_wide_beach",
         "stormy_open_baltic",
     }
+)
+
+_LEGACY_GENERIC_GEOGRAPHY = (
+    "dunes, pines, promenade, or baltic sea horizon",
+    "dunes, pines, promenade, sea horizon",
 )
 
 
@@ -101,28 +106,21 @@ def scene_policy_rejection(
     history: Sequence[Mapping[str, Any]],
     *,
     scene_family: str,
-    scene_cooldown: int = 0,
+    scene_cooldown: int = 3,
     macro_window: int = 5,
     max_open_beach: int = 2,
 ) -> tuple[str, Mapping[str, Any] | None]:
-    """Return a diversity rejection reason or ("", None).
+    """Return a hard diversity rejection reason or ("", None).
 
-    The production candidate selector owns the exact last-3 scene and last-4
-    composition cooldown and relaxes it only when a weather-specific catalog
-    cannot supply enough provider candidates. Keeping that relaxation out of
-    this final gate preserves secondary-backend availability. The always-on
-    hard rule here is the cross-scene macro quota: open beach/dunes may occupy
-    at most 2 of the last 5 real visual posts.
-
-    ``scene_cooldown`` remains available for deterministic tools/tests and for
-    the allocator-hardening phase where both providers can share the same fresh
-    candidate pool safely.
+    The allocator now keeps both providers on the same fresh candidate pool, so
+    the last-three scene-family cooldown can safely be enforced here as a final
+    invariant. The broader open-beach/dunes macro remains capped at 2 of the
+    last 5 real visual posts.
     """
     recent = recent_real_scene_entries(history, limit=max(scene_cooldown, macro_window))
-    if scene_cooldown > 0:
-        for entry in recent[:scene_cooldown]:
-            if str(entry.get("scene_family") or "") == str(scene_family or ""):
-                return "scene_cooldown", entry
+    for entry in recent[: max(0, int(scene_cooldown))]:
+        if str(entry.get("scene_family") or "") == str(scene_family or ""):
+            return "scene_cooldown", entry
 
     macro = scene_macro_family(scene_family)
     if macro == "open_beach_dunes":
@@ -149,6 +147,76 @@ def build_scene_contract(metadata: Mapping[str, Any]) -> str:
     )
 
 
+def _clean_must_show(line: str) -> str:
+    prefix, raw = line.split(":", 1)
+    items = [item.strip().rstrip(".") for item in raw.split(";") if item.strip()]
+    kept = [
+        item
+        for item in items
+        if not any(token in item.lower() for token in _LEGACY_GENERIC_GEOGRAPHY)
+    ]
+    return f"{prefix}: " + "; ".join(kept) + ("." if kept else "")
+
+
+def finalize_kld_provider_prompt(
+    prompt: str,
+    *,
+    metadata: Mapping[str, Any],
+    date_key: str | dt.date | None = None,
+) -> str:
+    """Apply the final shared provider contract to morning/evening prompts.
+
+    The upstream VisualRules layer still carries a legacy generic coast base
+    scene.  This finalizer removes that geography lock and any older controlled
+    composition line, then inserts exactly one scene-authoritative contract.
+    Provider/UI safety and summer vegetation are applied at the same final point
+    for both morning and evening delivery paths.
+    """
+    target = parse_date_key(date_key or metadata.get("target_date") or metadata.get("forecast_date"))
+    summer = bool(target and target.month in SUMMER_MONTHS)
+    out: list[str] = []
+    for line in str(prompt or "").splitlines():
+        stripped = line.strip()
+        if stripped.startswith(
+            (
+                "Base scene:",
+                "Regional setting:",
+                "Controlled composition:",
+                "Controlled scene:",
+                "Provider safety:",
+                "Summer vegetation adherence:",
+            )
+        ):
+            continue
+        if stripped.startswith("Must show:"):
+            cleaned = _clean_must_show(line)
+            if cleaned.split(":", 1)[1].strip(" ."):
+                out.append(cleaned)
+            continue
+        if summer and stripped.startswith("Palette:"):
+            out.append(
+                "Palette: humid northern Baltic grey-blue, fresh natural summer greens, "
+                "restrained pale sand and stone tones."
+            )
+            continue
+        out.append(line)
+
+    policy_lines = [
+        "Regional setting: one real Kaliningrad-region location; selected scene family controls the geography.",
+        build_scene_contract(metadata),
+        PROVIDER_NEGATIVE_GUARD,
+    ]
+    if summer:
+        policy_lines.append(SUMMER_VEGETATION_CUE)
+
+    insert_at = next(
+        (index for index, line in enumerate(out) if line.startswith("Text restrictions:")),
+        len(out),
+    )
+    out[insert_at:insert_at] = policy_lines
+    return "\n".join(out)
+
+
 __all__ = [
     "KLD_VISUAL_POLICY_VERSION",
     "PROVIDER_NEGATIVE_GUARD",
@@ -157,6 +225,7 @@ __all__ = [
     "SUMMER_VEGETATION_CUE",
     "apply_summer_vegetation_guard",
     "build_scene_contract",
+    "finalize_kld_provider_prompt",
     "parse_date_key",
     "recent_real_scene_entries",
     "scene_macro_family",

--- a/tools/kld_visual_fixture_image.py
+++ b/tools/kld_visual_fixture_image.py
@@ -50,6 +50,10 @@ from kld_visual_dedup import (  # noqa: E402
     load_kld_visual_history,
     record_kld_visual_publication,
 )
+from kld_visual_policy import (  # noqa: E402
+    KLD_VISUAL_POLICY_VERSION,
+    finalize_kld_provider_prompt,
+)
 from visual_context_kld import build_visual_context  # noqa: E402
 from visual_rules import apply_visual_rules, build_prompt_from_cues, to_json  # noqa: E402
 
@@ -204,12 +208,22 @@ def build_payload(
             visibility_context=visibility_context,
         )
     date_key = _extract_prompt_date(message, dt.date(2026, 6, 19))
-    metadata = kld_scene_metadata(
-        ctx,
+    metadata = dict(
+        kld_scene_metadata(
+            ctx,
+            date_key=date_key,
+            post_type=post_type,
+            source_text=message,
+            variation_attempt=variation_attempt,
+        )
+    )
+    metadata["prompt_version"] = (
+        f"{metadata.get('prompt_version', 'unknown')}+{KLD_VISUAL_POLICY_VERSION}"
+    )
+    image_prompt = finalize_kld_provider_prompt(
+        image_prompt,
+        metadata=metadata,
         date_key=date_key,
-        post_type=post_type,
-        source_text=message,
-        variation_attempt=variation_attempt,
     )
     cache_key = kld_visual_cache_key(metadata)
     return {
@@ -264,6 +278,7 @@ def _base_outcome(*, post_type: str) -> dict[str, Any]:
         "cover_validation": None,
         "local_cover_published": False,
         "post_type": post_type,
+        "visual_policy_version": KLD_VISUAL_POLICY_VERSION,
         "provider_error": None,
         "provider_errors": [],
         "provider_attempts": [],
@@ -276,6 +291,7 @@ def _base_outcome(*, post_type: str) -> dict[str, Any]:
         "dedup_distance": None,
         "scene_cooldown": [],
         "composition_cooldown": [],
+        "candidate_pool": [],
         "dedup_results": [],
     }
 
@@ -443,13 +459,16 @@ def _candidate_payloads(
     selected_attempts: list[int] = []
     used_scenes: set[str] = set()
     used_compositions: set[str] = set()
-    for cooldown_mode in ("strict", "scene_only", "relaxed"):
+    # Exact scene cooldown is never relaxed. The weather-specific catalogs have
+    # at least six scenes, so blocking the last three still leaves three fresh
+    # scenes. Composition cooldown may relax only after fresh scenes are kept.
+    for cooldown_mode in ("strict", "scene_only"):
         for variation_attempt, metadata in candidate_metadata:
             scene = str(metadata["scene_family"])
             composition = str(metadata["composition"])
             if scene in used_scenes or composition in used_compositions:
                 continue
-            if cooldown_mode in {"strict", "scene_only"} and scene in blocked_scenes:
+            if scene in blocked_scenes:
                 continue
             if cooldown_mode == "strict" and composition in blocked_compositions:
                 continue
@@ -499,6 +518,18 @@ def _provider_attempt_payload(
     }
 
 
+def _rejection_fallback_reason(reasons: list[str]) -> str:
+    if any(str(reason).startswith("content_guard:") for reason in reasons):
+        return "semantic_mismatch"
+    if any(reason in {"scene_cooldown", "scene_macro_cooldown"} for reason in reasons):
+        return "scene_policy_rejected"
+    if "near_duplicate" in reasons:
+        return "near_duplicate"
+    if "exact_duplicate" in reasons:
+        return "exact_duplicate"
+    return "candidate_rejected"
+
+
 def execute_image_delivery(
     *,
     args: argparse.Namespace,
@@ -537,16 +568,28 @@ def execute_image_delivery(
         message=message,
         visibility_context=visibility_context,
         history_path=history_path,
-        count=3 * len(providers),
+        count=3,
     )
     outcome["scene_cooldown"] = scene_cooldown
     outcome["composition_cooldown"] = composition_cooldown
+    outcome["candidate_pool"] = [
+        {
+            "variation_attempt": int(candidate.get("variation_attempt") or 0),
+            "scene_family": str(candidate["metadata"].get("scene_family") or ""),
+            "composition": str(candidate["metadata"].get("composition") or ""),
+            "cache_key": str(candidate.get("cache_key") or ""),
+        }
+        for candidate in candidates
+    ]
     duplicate_reasons: list[str] = []
     provider_failed = False
     provider_failure_kinds: list[str] = []
     for provider_index, (backend, generator) in enumerate(providers):
-        start = provider_index * 3
-        provider_candidates = candidates[start : start + 3]
+        if candidates:
+            offset = provider_index % len(candidates)
+            provider_candidates = candidates[offset:] + candidates[:offset]
+        else:
+            provider_candidates = []
         for candidate in provider_candidates:
             metadata = candidate["metadata"]
             try:
@@ -654,25 +697,26 @@ def execute_image_delivery(
                     record_publication=record_publication,
                 )
             duplicate_reasons.append(str(duplicate.reason))
-            # Hard rejection: a near duplicate is never promoted merely because
-            # it is the least similar of the rejected candidates.
+            # Hard rejection: a near duplicate, semantic mismatch, or scene
+            # policy violation is never promoted merely because it is the least
+            # similar of the rejected candidates.
 
     if provider_failed and duplicate_reasons:
-        fallback_reason = "provider_failure_after_duplicate"
+        fallback_reason = "provider_failure_after_rejection"
     elif provider_failed:
         fallback_reason = (
             "invalid_image"
             if provider_failure_kinds and all(kind == "invalid_image" for kind in provider_failure_kinds)
             else "provider_failure"
         )
-    elif "near_duplicate" in duplicate_reasons:
-        fallback_reason = "near_duplicate"
     else:
-        fallback_reason = "exact_duplicate"
+        fallback_reason = _rejection_fallback_reason(duplicate_reasons)
     outcome["fallback_reason"] = fallback_reason
     if duplicate_reasons and not provider_failed:
-        outcome["error_type"] = "DuplicateOnly"
-        outcome["error_message"] = "all generated candidates matched visual history"
+        outcome["error_type"] = "CandidateRejected"
+        outcome["error_message"] = (
+            "all generated candidates were rejected: " + ", ".join(sorted(set(duplicate_reasons)))
+        )
     print(
         "::warning::KLD AI image unavailable after provider/dedup ladder; "
         "validated local informative cover will be attempted."
@@ -855,6 +899,7 @@ def main(argv: list[str] | None = None) -> int:
         "cache_key": payload["cache_key"],
         "metadata": payload["metadata"],
         "prompt_sha256": hashlib.sha256(payload["image_prompt"].encode("utf-8")).hexdigest(),
+        "visual_policy_version": KLD_VISUAL_POLICY_VERSION,
         "visibility_context": dict(visibility_context or {}),
         "local_cover_renderer": LOCAL_COVER_RENDERER_VERSION,
     }

--- a/tools/test_kld_evening_allocator_policy.py
+++ b/tools/test_kld_evening_allocator_policy.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Offline regressions for shared KLD evening prompt policy and provider allocator."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from tempfile import TemporaryDirectory
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from kld_visual_dedup import KldVisualDuplicateResult  # noqa: E402
+from kld_visual_policy import (  # noqa: E402
+    KLD_VISUAL_POLICY_VERSION,
+    SUMMER_VEGETATION_CUE,
+    scene_policy_rejection,
+)
+from tools.kld_visual_fixture_image import (  # noqa: E402
+    FIXTURES,
+    _candidate_payloads,
+    _rejection_fallback_reason,
+    build_payload,
+    execute_image_delivery,
+)
+
+
+def _args(root: Path, *, scenario: str = "storm") -> argparse.Namespace:
+    return argparse.Namespace(
+        scenario=scenario,
+        message_file="",
+        post_type="evening",
+        generate=False,
+        send_to_test=True,
+        chat_id="test",
+        caption="",
+        history_namespace="test",
+        result_file=str(root / "image_result.json"),
+        prompt_metadata_file=str(root / "image_prompt_metadata.json"),
+        cover_path=str(root / "cover.png"),
+    )
+
+
+def _ppm(path: Path, value: int = 90) -> str:
+    width = 32
+    height = 32
+    raw = bytes([value, min(255, value + 20), min(255, value + 40)]) * width * height
+    path.write_bytes(f"P6\n{width} {height}\n255\n".encode("ascii") + raw)
+    return str(path)
+
+
+def _accepted() -> KldVisualDuplicateResult:
+    return KldVisualDuplicateResult(
+        accepted=True,
+        reason="accepted",
+        sha256="a" * 64,
+        perceptual_hash="0" * 16,
+        min_distance=24,
+    )
+
+
+def evening_prompt_is_scene_authoritative_and_summer_green() -> None:
+    message = (
+        "<b>🌅 Калининградская область завтра (08.08.2026)</b>\n"
+        "🏙 Калининград — 22/15 °C • ☁️ облачно • 💨 4 м/с\n"
+        "🌊 Балтийск — 20/15 °C • 🌊 19 °C\n"
+        "#Калининград #погода\n"
+    )
+    payload = build_payload(message, "summer_evening", post_type="evening")
+    prompt = payload["image_prompt"]
+    assert "Base scene:" not in prompt
+    assert "Controlled composition:" not in prompt
+    assert prompt.count("Controlled scene:") == 1
+    assert "Regional setting: one real Kaliningrad-region location" in prompt
+    assert "Provider safety: no map, no satellite imagery" in prompt
+    assert SUMMER_VEGETATION_CUE in prompt
+    assert "dunes, pines, promenade, or Baltic sea horizon" not in prompt
+    assert payload["metadata"]["prompt_version"].endswith("+" + KLD_VISUAL_POLICY_VERSION)
+    assert f"prompt_version={payload['metadata']['prompt_version']}" in payload["cache_key"]
+
+
+def winter_evening_prompt_does_not_force_summer_green() -> None:
+    message = (
+        "<b>🌅 Калининградская область завтра (08.12.2026)</b>\n"
+        "🏙 Калининград — 3/-1 °C • ☁️ облачно • 💨 4 м/с\n"
+        "#Калининград #погода\n"
+    )
+    payload = build_payload(message, "winter_evening", post_type="evening")
+    assert SUMMER_VEGETATION_CUE not in payload["image_prompt"]
+    assert "Controlled scene:" in payload["image_prompt"]
+    assert "Base scene:" not in payload["image_prompt"]
+
+
+def storm_allocator_keeps_last_three_scenes_hard_blocked() -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        history_path = root / "history.json"
+        blocked = [
+            "stormy_open_baltic",
+            "baltiysk_breakwater",
+            "svetlogorsk_cliff_coast",
+        ]
+        history_path.write_text(
+            json.dumps(
+                [
+                    {"date": "2026-06-16", "scene_family": blocked[2], "composition": "old-c"},
+                    {"date": "2026-06-17", "scene_family": blocked[1], "composition": "old-b"},
+                    {"date": "2026-06-18", "scene_family": blocked[0], "composition": "old-a"},
+                ]
+            ),
+            encoding="utf-8",
+        )
+        candidates, scene_cooldown, _ = _candidate_payloads(
+            args=_args(root),
+            message=FIXTURES["storm"],
+            visibility_context=None,
+            history_path=history_path,
+            count=3,
+        )
+        scenes = [str(item["metadata"]["scene_family"]) for item in candidates]
+        assert len(candidates) == 3
+        assert len(set(scenes)) == 3
+        assert set(scene_cooldown) == set(blocked)
+        assert not (set(scenes) & set(blocked))
+
+
+def secondary_backend_rotates_same_fresh_candidate_pool() -> None:
+    class PollinationsFailure(RuntimeError):
+        backend = "pollinations"
+        reason = "provider_failure"
+        attempts = []
+
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        history_path = root / "history.json"
+        history_path.write_text(
+            json.dumps(
+                [
+                    {"date": "2026-06-16", "scene_family": "stormy_open_baltic", "composition": "old-c"},
+                    {"date": "2026-06-17", "scene_family": "baltiysk_breakwater", "composition": "old-b"},
+                    {"date": "2026-06-18", "scene_family": "svetlogorsk_cliff_coast", "composition": "old-a"},
+                ]
+            ),
+            encoding="utf-8",
+        )
+        args = _args(root)
+        initial = build_payload(FIXTURES["storm"], "storm", post_type="evening")
+        events: list[str] = []
+
+        def pollinations(**kwargs):
+            raise PollinationsFailure("offline provider failure")
+
+        def stable_horde(**kwargs):
+            events.append("stable_horde")
+            return _ppm(root / "horde.ppm")
+
+        outcome = execute_image_delivery(
+            args=args,
+            message=FIXTURES["storm"],
+            initial_payload=initial,
+            visibility_context=None,
+            history_path=history_path,
+            generate_image=pollinations,
+            secondary_generate_image=stable_horde,
+            evaluate_candidate=lambda *args, **kwargs: _accepted(),
+            cover_renderer=lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("cover not expected")),
+            validate_cover=lambda *args, **kwargs: {"valid": True, "errors": []},
+            send_photo=lambda *args, **kwargs: events.append("photo") or 123,
+            record_publication=lambda **kwargs: events.append("history") or {"sha256": "b" * 64},
+        )
+        assert outcome["backend"] == "stable_horde"
+        assert len(outcome["candidate_pool"]) == 3
+        first_pollinations = outcome["provider_attempts"][0]
+        first_horde = outcome["provider_attempts"][1]
+        assert first_pollinations["backend"] == "pollinations"
+        assert first_horde["backend"] == "stable_horde"
+        assert first_pollinations["scene_family"] == outcome["candidate_pool"][0]["scene_family"]
+        assert first_horde["scene_family"] == outcome["candidate_pool"][1]["scene_family"]
+        assert first_pollinations["scene_family"] != first_horde["scene_family"]
+        assert not (set(outcome["scene_cooldown"]) & {item["scene_family"] for item in outcome["candidate_pool"]})
+        assert events == ["stable_horde", "photo", "history"]
+
+
+def final_scene_policy_is_hard_and_reasons_are_explicit() -> None:
+    history = [
+        {"date": "2026-08-05", "scene_family": "quiet_lagoon_coast"},
+        {"date": "2026-08-06", "scene_family": "zelenogradsk_promenade"},
+        {"date": "2026-08-07", "scene_family": "pine_forest_sea_path"},
+    ]
+    reason, matched = scene_policy_rejection(history, scene_family="pine_forest_sea_path")
+    assert reason == "scene_cooldown"
+    assert matched and matched["scene_family"] == "pine_forest_sea_path"
+    assert _rejection_fallback_reason(["content_guard:screen_or_ui_chrome"]) == "semantic_mismatch"
+    assert _rejection_fallback_reason(["scene_cooldown"]) == "scene_policy_rejected"
+    assert _rejection_fallback_reason(["near_duplicate"]) == "near_duplicate"
+
+
+TESTS = [
+    evening_prompt_is_scene_authoritative_and_summer_green,
+    winter_evening_prompt_does_not_force_summer_green,
+    storm_allocator_keeps_last_three_scenes_hard_blocked,
+    secondary_backend_rotates_same_fresh_candidate_pool,
+    final_scene_policy_is_hard_and_reasons_are_explicit,
+]
+
+
+def main() -> None:
+    for test in TESTS:
+        test()
+        print(f"PASS: {test.__name__}")
+    print(f"OK: {len(TESTS)} KLD evening/allocator offline checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_kld_visual_season_boundary.py
+++ b/tools/test_kld_visual_season_boundary.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Offline target-date boundary checks for KLD seasonal visual policy."""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from kld_visual_policy import SUMMER_VEGETATION_CUE, finalize_kld_provider_prompt  # noqa: E402
+
+
+BASE_PROMPT = "\n".join(
+    [
+        "Base scene: Baltic coast near Kaliningrad, dunes, pines, promenade, sea horizon.",
+        "Palette: cool Baltic grey-blue, muted sand, pine green, restrained northern light.",
+        "Must show: recognizable Baltic/Kaliningrad atmosphere; dunes, pines, promenade, or Baltic sea horizon.",
+        "Text restrictions: no text, no captions, no labels.",
+    ]
+)
+
+
+def _metadata(*, forecast_date: str, target_date: str) -> dict[str, str]:
+    return {
+        "forecast_date": forecast_date,
+        "target_date": target_date,
+        "scene_family": "pine_forest_sea_path",
+        "scene_text": "pine forest sea path opening toward the Baltic shore, realistic northern vegetation",
+        "composition": "pine-framed side composition",
+    }
+
+
+def may_evening_for_june_target_is_summer() -> None:
+    prompt = finalize_kld_provider_prompt(
+        BASE_PROMPT,
+        metadata=_metadata(forecast_date="2026-05-31", target_date="2026-06-01"),
+        date_key="2026-05-31",
+    )
+    assert SUMMER_VEGETATION_CUE in prompt
+    assert "fresh natural summer greens" in prompt
+
+
+def august_evening_for_september_target_is_not_forced_summer() -> None:
+    prompt = finalize_kld_provider_prompt(
+        BASE_PROMPT,
+        metadata=_metadata(forecast_date="2026-08-31", target_date="2026-09-01"),
+        date_key="2026-08-31",
+    )
+    assert SUMMER_VEGETATION_CUE not in prompt
+    assert "fresh natural summer greens" not in prompt
+
+
+def main() -> None:
+    may_evening_for_june_target_is_summer()
+    print("PASS: may_evening_for_june_target_is_summer")
+    august_evening_for_september_target_is_not_forced_summer()
+    print("PASS: august_evening_for_september_target_is_not_forced_summer")
+    print("OK: 2 KLD target-date seasonal boundary checks passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Scope
Second implementation phase of the accepted KLD visual-hardening plan: shared evening provider policy plus fallback-safe allocator hardening.

### What changes
- applies one final scene-authoritative provider prompt contract to both morning and evening delivery paths;
- removes the legacy generic `Base scene` and older `Controlled composition` line before the provider sees the prompt;
- removes the generic `dunes, pines, promenade, or Baltic sea horizon` must-show bias;
- applies the shared June-August green Baltic vegetation rule to evening delivery as well, based on the visual **target date**;
- keeps map/satellite/screenshot/UI provider-negative guard at the final provider boundary;
- versions delivered prompts/history as `v6+kld_visual_policy_v2` without changing the lower-level builder API;
- selector now never relaxes the last-3 scene-family cooldown; only composition cooldown may relax;
- both Pollinations and Stable Horde consume the same 3 fresh candidate pool, with the secondary backend rotated to start from the next candidate;
- makes the last-3 scene-family rule a hard final invariant again;
- keeps the existing hard open-beach/dunes macro quota (`<=2/5`);
- records `visual_policy_version` and the selected `candidate_pool` in image diagnostics;
- distinguishes semantic/content rejection, scene-policy rejection, near-duplicate and exact-duplicate fallback reasons.

### Reliability rationale
The smallest weather-specific catalog is the storm catalog and it already contains six distinct scene families. With the last three production scene families blocked, three fresh storm scenes remain. Therefore the selector can keep scene cooldown hard and still provide a complete three-candidate pool. Sharing that fresh pool between providers prevents Stable Horde from being assigned previously used scenes while retaining backend diversity through rotated candidate order.

### Seasonal boundary
Seasonal vegetation follows `target_date`, not merely publication date. This means an evening forecast posted on 31 May for 1 June receives the summer-green rule, while an evening forecast posted on 31 August for 1 September does not force the June-August palette.

### Safety
- no Telegram calls;
- no image providers invoked;
- no production workflow dispatch;
- no Safecast/Schumann/data files changed;
- no text/editor/forecast logic changed;
- no force push.

### Validation
Focused offline regression scripts are committed:
- `tools/test_kld_evening_allocator_policy.py` — evening provider contract, hard fresh-scene allocation, shared provider pool, explicit rejection reasons;
- `tools/test_kld_visual_season_boundary.py` — May→June and August→September target-date boundaries.

Existing PR #18 focused policy tests remain compatible, including the explicit `scene family is authoritative` contract.

**CI limitation:** the repository's automatic `PR checks (smoke daily & FX)` workflow currently runs only the daily dry-run and FX dry-run. It does **not** execute the new focused visual scripts. Therefore a green PR smoke confirms general daily/FX compatibility but must not be described as execution of the allocator/policy regression suite. The separate `KLD Visual Smoke Tests` workflow is manual and currently runs only `tools/test_visual_kld.py`; it has not been dispatched for this PR.
