### PR TITLE
Complete KLD visual decision policy

### DIFF
--- a/kld_image_first.py
+++ b/kld_image_first.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
-from typing import Any, Callable, Sequence
+from typing import Any, Callable, Mapping, Sequence
+
+from kld_visual_policy import scene_macro_family, seasonal_guard_label
 
 
 FORMAT_V2_BEGIN = "===== FORMAT_V2 MESSAGE BEGIN ====="
@@ -31,6 +33,64 @@ def _load_json(path: str | Path) -> dict[str, Any] | None:
     except (OSError, UnicodeError, json.JSONDecodeError):
         return None
     return payload if isinstance(payload, dict) else None
+
+
+def _visual_decision(
+    result: Mapping[str, Any],
+    prompt_metadata: Mapping[str, Any] | None,
+    *,
+    mode: str,
+) -> dict[str, Any]:
+    prompt_metadata = dict(prompt_metadata or {})
+    metadata_raw = prompt_metadata.get("metadata")
+    metadata = dict(metadata_raw) if isinstance(metadata_raw, Mapping) else {}
+
+    scene_family = str(result.get("selected_scene_family") or metadata.get("scene_family") or "")
+    composition = str(result.get("selected_composition") or metadata.get("composition") or "")
+    backend = str(result.get("backend") or "none")
+    dedup_reason = str(result.get("dedup_reason") or "")
+    telegram_image_sent = bool(result.get("telegram_image_sent"))
+
+    if backend == "local_informative_cover":
+        content_guard: dict[str, Any] = {
+            "valid": None,
+            "reason": "not_applicable_local_cover",
+        }
+    elif telegram_image_sent:
+        content_guard = {"valid": True, "reason": "accepted"}
+    elif dedup_reason.startswith("content_guard:"):
+        content_guard = {
+            "valid": False,
+            "reason": dedup_reason.split(":", 1)[1],
+        }
+    else:
+        content_guard = {"valid": None, "reason": "not_selected"}
+
+    target_date = str(metadata.get("target_date") or metadata.get("forecast_date") or "")
+    return {
+        "backend": backend,
+        "post_type": mode,
+        "weather_main": str(metadata.get("weather_scenario") or "unknown"),
+        "visibility_condition": str(metadata.get("visibility_condition") or "clear"),
+        "wind_gust_category": str(metadata.get("wind_gust_category") or "wind_unknown"),
+        "scene_route": str(metadata.get("scene_route") or "unknown"),
+        "seasonal_guard": seasonal_guard_label(target_date),
+        "scene_family": scene_family,
+        "scene_macro_family": scene_macro_family(scene_family),
+        "composition": composition,
+        "content_guard": content_guard,
+        "dedup": {
+            "reason": dedup_reason or "unknown",
+            "distance": result.get("dedup_distance"),
+        },
+        "fallback_reason": str(result.get("fallback_reason") or ""),
+        "visual_policy_version": str(
+            result.get("visual_policy_version")
+            or prompt_metadata.get("visual_policy_version")
+            or "unknown"
+        ),
+        "published": telegram_image_sent,
+    }
 
 
 def extract_format_v2_message(output: str) -> str:
@@ -78,6 +138,7 @@ def run_image_first_publication(
         "text_sent": False,
         "telegram_text_message_ids": [],
         "mode": mode,
+        "visual_decision": None,
     }
     _write_json(result_path, result)
     _write_json(
@@ -146,6 +207,11 @@ def run_image_first_publication(
                 error_message=f"image tool exited with {image_returncode}",
             )
     result["image_process_returncode"] = image_returncode
+    result["visual_decision"] = _visual_decision(
+        result,
+        _load_json(prompt_metadata_path),
+        mode=mode,
+    )
 
     if image_returncode != 0 or not result.get("telegram_image_sent"):
         print("::warning::KLD image unavailable; text publication continued.")

--- a/kld_visual_dedup.py
+++ b/kld_visual_dedup.py
@@ -255,7 +255,7 @@ def evaluate_kld_visual_candidate(
     perceptual = dhash_file(image_path)
 
     # Local covers are deterministic cards and are validated semantically by
-    # kld_informative_cover.py.  The provider content guard is for AI images.
+    # kld_informative_cover.py. The provider content guard is for AI images.
     if str(scene_family or "") != "local_informative_cover":
         verdict = inspect_kld_provider_image(image_path)
         verdict_payload = verdict.to_dict()
@@ -309,7 +309,11 @@ def evaluate_kld_visual_candidate(
             )
 
     if str(scene_family or "") != "local_informative_cover":
-        policy_reason, policy_match = scene_policy_rejection(history, scene_family=scene_family)
+        policy_reason, policy_match = scene_policy_rejection(
+            history,
+            scene_family=scene_family,
+            composition=composition,
+        )
         if policy_reason:
             return KldVisualDuplicateResult(
                 accepted=False,

--- a/kld_visual_policy.py
+++ b/kld_visual_policy.py
@@ -3,15 +3,15 @@
 """Shared visual policy for Kaliningrad image prompts and history gates.
 
 The policy is intentionally deterministic and side-effect free. It keeps
-seasonal appearance and scene diversity rules in one place so morning and
-evening builders can use the same contract.
+seasonal appearance, weather-aware scene routing and visual diversity rules in
+one place so morning and evening delivery use the same contract.
 """
 from __future__ import annotations
 
 import datetime as dt
-from typing import Any, Mapping, Sequence
+from typing import Any, Mapping, MutableMapping, Sequence
 
-KLD_VISUAL_POLICY_VERSION = "kld_visual_policy_v2"
+KLD_VISUAL_POLICY_VERSION = "kld_visual_policy_v3"
 SUMMER_MONTHS = frozenset({6, 7, 8})
 
 SUMMER_VEGETATION_CUE = (
@@ -47,6 +47,73 @@ _LEGACY_GENERIC_GEOGRAPHY = (
     "dunes, pines, promenade, sea horizon",
 )
 
+_SCENE_TEXT = {
+    "curonian_spit_dunes": "Curonian Spit dunes with marram grass, pine forest edge and open Baltic water",
+    "svetlogorsk_cliff_coast": "Svetlogorsk cliff coast with steep green slope, sea below and northern sky",
+    "zelenogradsk_promenade": "Zelenogradsk seaside promenade with Baltic horizon and realistic coastal railings",
+    "baltiysk_breakwater": "Baltiysk breakwater stones, working-harbour edge in the distance and open sea",
+    "yantarny_wide_beach": "Yantarny wide pale sand beach with low dune grasses and spacious Baltic horizon",
+    "pine_forest_sea_path": "pine forest sea path opening toward the Baltic shore, realistic northern vegetation",
+    "stormy_open_baltic": "open Baltic sea view with restless water, whitecaps when windy and layered cloud bands",
+    "quiet_lagoon_coast": "quiet lagoon-like Baltic coast with reeds, low shore and subdued northern atmosphere",
+    "wet_seaside_promenade": "wet seaside promenade after rain with dry-to-damp stone texture and realistic reflections",
+    "elevated_baltic_overlook": "elevated Baltic overlook from a dune or cliff path, wide sea and coastline below",
+    "kaliningrad_urban_coastal_view": "urban Baltic coastal edge with modest Kaliningrad-region architecture, promenade and sea horizon",
+    "rainy_coastal_road": "rain-darkened coastal road near dunes and pines, with the Baltic shoreline visible beyond",
+}
+
+WEATHER_SCENE_ROUTES: dict[str, tuple[str, ...]] = {
+    "fog_visibility": (
+        "quiet_lagoon_coast",
+        "pine_forest_sea_path",
+        "curonian_spit_dunes",
+        "elevated_baltic_overlook",
+        "zelenogradsk_promenade",
+    ),
+    "rain": (
+        "wet_seaside_promenade",
+        "rainy_coastal_road",
+        "zelenogradsk_promenade",
+        "kaliningrad_urban_coastal_view",
+        "baltiysk_breakwater",
+        "pine_forest_sea_path",
+    ),
+    "storm": (
+        "baltiysk_breakwater",
+        "svetlogorsk_cliff_coast",
+        "stormy_open_baltic",
+        "wet_seaside_promenade",
+        "rainy_coastal_road",
+        "elevated_baltic_overlook",
+    ),
+    "strong_wind": (
+        "baltiysk_breakwater",
+        "svetlogorsk_cliff_coast",
+        "elevated_baltic_overlook",
+        "zelenogradsk_promenade",
+        "yantarny_wide_beach",
+    ),
+    "calm": (
+        "kaliningrad_urban_coastal_view",
+        "pine_forest_sea_path",
+        "quiet_lagoon_coast",
+        "zelenogradsk_promenade",
+        "curonian_spit_dunes",
+        "yantarny_wide_beach",
+    ),
+}
+
+_FOG_VISIBILITY = frozenset(
+    {
+        "dense_fog",
+        "fog",
+        "mist",
+        "reduced_visibility",
+        "dust_haze",
+        "mixed_visibility",
+    }
+)
+
 
 def parse_date_key(value: str | dt.date | None) -> dt.date | None:
     if isinstance(value, dt.date):
@@ -58,6 +125,13 @@ def parse_date_key(value: str | dt.date | None) -> dt.date | None:
         return dt.date.fromisoformat(raw[:10])
     except ValueError:
         return None
+
+
+def seasonal_guard_label(value: str | dt.date | None) -> str:
+    target = parse_date_key(value)
+    if target and target.month in SUMMER_MONTHS:
+        return "summer_green"
+    return "seasonal_default"
 
 
 def apply_summer_vegetation_guard(prompt: str, date_key: str | dt.date | None) -> str:
@@ -90,6 +164,53 @@ def scene_macro_family(scene_family: str) -> str:
     return scene or "unknown"
 
 
+def weather_route_key(metadata: Mapping[str, Any]) -> str:
+    visibility = str(metadata.get("visibility_condition") or "clear").strip().lower()
+    weather = str(metadata.get("weather_scenario") or "unknown").strip().lower()
+    gust = str(metadata.get("wind_gust_category") or "wind_unknown").strip().lower()
+    if visibility in _FOG_VISIBILITY or weather == "fog":
+        return "fog_visibility"
+    if weather == "storm":
+        return "storm"
+    if weather in {"rain", "drizzle"}:
+        return "rain"
+    if gust in {"gust_10_14", "gust_15_plus"}:
+        return "strong_wind"
+    return "calm"
+
+
+def weather_route_scenes(metadata: Mapping[str, Any]) -> tuple[str, ...]:
+    return WEATHER_SCENE_ROUTES[weather_route_key(metadata)]
+
+
+def apply_weather_scene_route(metadata: Mapping[str, Any]) -> dict[str, Any]:
+    """Bias the final provider scene toward weather-relevant KLD geography.
+
+    Existing date-based selection is preserved when it is already compatible
+    with the active weather route. Otherwise a deterministic route scene is
+    chosen from variation_attempt. Mutable metadata is updated in-place so the
+    cache key, final dedup gate and history all describe the scene actually sent
+    to the provider.
+    """
+    routed = dict(metadata)
+    route_key = weather_route_key(routed)
+    route = WEATHER_SCENE_ROUTES[route_key]
+    current = str(routed.get("scene_family") or "")
+    if current not in route:
+        try:
+            attempt = int(routed.get("variation_attempt") or 0)
+        except (TypeError, ValueError):
+            attempt = 0
+        stable_offset = sum(ord(char) for char in current) % len(route) if current else 0
+        current = route[(attempt + stable_offset) % len(route)]
+        routed["scene_family"] = current
+        routed["scene_text"] = _SCENE_TEXT[current]
+    routed["scene_route"] = route_key
+    if isinstance(metadata, MutableMapping):
+        metadata.update(routed)
+    return routed
+
+
 def recent_real_scene_entries(history: Sequence[Mapping[str, Any]], *, limit: int = 5) -> list[Mapping[str, Any]]:
     out: list[Mapping[str, Any]] = []
     for entry in reversed(list(history)):
@@ -106,21 +227,30 @@ def scene_policy_rejection(
     history: Sequence[Mapping[str, Any]],
     *,
     scene_family: str,
+    composition: str = "",
     scene_cooldown: int = 3,
+    composition_cooldown: int = 4,
     macro_window: int = 5,
     max_open_beach: int = 2,
 ) -> tuple[str, Mapping[str, Any] | None]:
     """Return a hard diversity rejection reason or ("", None).
 
-    The allocator now keeps both providers on the same fresh candidate pool, so
-    the last-three scene-family cooldown can safely be enforced here as a final
-    invariant. The broader open-beach/dunes macro remains capped at 2 of the
-    last 5 real visual posts.
+    Both exact scene-family and composition cooldowns are final invariants. The
+    broader open-beach/dunes macro remains capped at 2 of the last 5 real visual
+    posts.
     """
-    recent = recent_real_scene_entries(history, limit=max(scene_cooldown, macro_window))
+    recent = recent_real_scene_entries(
+        history,
+        limit=max(scene_cooldown, composition_cooldown, macro_window),
+    )
     for entry in recent[: max(0, int(scene_cooldown))]:
         if str(entry.get("scene_family") or "") == str(scene_family or ""):
             return "scene_cooldown", entry
+
+    if composition:
+        for entry in recent[: max(0, int(composition_cooldown))]:
+            if str(entry.get("composition") or "") == str(composition):
+                return "composition_cooldown", entry
 
     macro = scene_macro_family(scene_family)
     if macro == "open_beach_dunes":
@@ -168,13 +298,14 @@ def finalize_kld_provider_prompt(
 
     The upstream VisualRules layer still carries a legacy generic coast base
     scene. This finalizer removes that geography lock and any older controlled
-    composition line, then inserts exactly one scene-authoritative contract.
-    Provider/UI safety and summer vegetation are applied at the same final point
-    for both morning and evening delivery paths. Seasonal appearance follows
-    the visual target date (important for evening forecasts crossing a month).
+    composition line, applies weather-aware scene routing, then inserts exactly
+    one scene-authoritative contract. Provider/UI safety and summer vegetation
+    are applied at the same final point for both morning and evening delivery.
+    Seasonal appearance follows the visual target date.
     """
+    routed_metadata = apply_weather_scene_route(metadata)
     target = parse_date_key(
-        metadata.get("target_date") or date_key or metadata.get("forecast_date")
+        routed_metadata.get("target_date") or date_key or routed_metadata.get("forecast_date")
     )
     summer = bool(target and target.month in SUMMER_MONTHS)
     out: list[str] = []
@@ -188,6 +319,7 @@ def finalize_kld_provider_prompt(
                 "Controlled scene:",
                 "Provider safety:",
                 "Summer vegetation adherence:",
+                "Weather scene route:",
             )
         ):
             continue
@@ -206,7 +338,8 @@ def finalize_kld_provider_prompt(
 
     policy_lines = [
         "Regional setting: one real Kaliningrad-region location; selected scene family controls the geography.",
-        build_scene_contract(metadata),
+        f"Weather scene route: {routed_metadata.get('scene_route', 'calm')}.",
+        build_scene_contract(routed_metadata),
         PROVIDER_NEGATIVE_GUARD,
     ]
     if summer:
@@ -226,11 +359,16 @@ __all__ = [
     "SCENE_NEUTRAL_PHOTO_CONTRACT",
     "SUMMER_MONTHS",
     "SUMMER_VEGETATION_CUE",
+    "WEATHER_SCENE_ROUTES",
     "apply_summer_vegetation_guard",
+    "apply_weather_scene_route",
     "build_scene_contract",
     "finalize_kld_provider_prompt",
     "parse_date_key",
     "recent_real_scene_entries",
     "scene_macro_family",
     "scene_policy_rejection",
+    "seasonal_guard_label",
+    "weather_route_key",
+    "weather_route_scenes",
 ]

--- a/tools/test_kld_august_2026_visual_regression.py
+++ b/tools/test_kld_august_2026_visual_regression.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Regression fixtures derived from the KLD channel export for 01-08 Aug 2026.
+
+The fixtures intentionally assert policy invariants rather than reproducing old
+provider images. They preserve the real weather categories/gust regimes that
+exposed the repetitive beach visual problem.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from kld_visual_policy import (  # noqa: E402
+    WEATHER_SCENE_ROUTES,
+    apply_weather_scene_route,
+    scene_macro_family,
+    scene_policy_rejection,
+    seasonal_guard_label,
+    weather_route_key,
+)
+
+
+AUGUST_CASES = (
+    {
+        "date": "2026-08-01",
+        "weather_scenario": "rain",
+        "wind_gust_category": "calm_to_breezy",
+        "visibility_condition": "clear",
+        "expected_route": "rain",
+    },
+    {
+        "date": "2026-08-02",
+        "weather_scenario": "drizzle",
+        "wind_gust_category": "gust_7_9",
+        "visibility_condition": "clear",
+        "expected_route": "rain",
+    },
+    {
+        "date": "2026-08-03",
+        "weather_scenario": "cloudy",
+        "wind_gust_category": "calm_to_breezy",
+        "visibility_condition": "clear",
+        "expected_route": "calm",
+    },
+    {
+        "date": "2026-08-04",
+        "weather_scenario": "cloudy",
+        "wind_gust_category": "gust_7_9",
+        "visibility_condition": "clear",
+        "expected_route": "calm",
+    },
+    {
+        "date": "2026-08-05",
+        "weather_scenario": "cloudy",
+        "wind_gust_category": "gust_7_9",
+        "visibility_condition": "clear",
+        "expected_route": "calm",
+    },
+    {
+        "date": "2026-08-06",
+        "weather_scenario": "rain",
+        "wind_gust_category": "calm_to_breezy",
+        "visibility_condition": "clear",
+        "expected_route": "rain",
+    },
+    {
+        "date": "2026-08-07",
+        "weather_scenario": "cloudy",
+        "wind_gust_category": "gust_10_14",
+        "visibility_condition": "clear",
+        "expected_route": "strong_wind",
+    },
+    {
+        "date": "2026-08-08",
+        "weather_scenario": "cloudy",
+        "wind_gust_category": "gust_10_14",
+        "visibility_condition": "clear",
+        "expected_route": "strong_wind",
+    },
+)
+
+
+def _metadata(case, attempt: int = 0):
+    return {
+        "forecast_date": case["date"],
+        "target_date": case["date"],
+        "post_type": "morning",
+        "scene_family": "curonian_spit_dunes",
+        "scene_text": "Curonian Spit dunes",
+        "composition": "wide diagonal shoreline composition",
+        "weather_scenario": case["weather_scenario"],
+        "wind_gust_category": case["wind_gust_category"],
+        "visibility_condition": case["visibility_condition"],
+        "variation_attempt": str(attempt),
+    }
+
+
+def all_august_cases_use_summer_green() -> None:
+    for case in AUGUST_CASES:
+        assert seasonal_guard_label(case["date"]) == "summer_green", case
+
+
+def august_weather_routes_match_real_regimes() -> None:
+    for case in AUGUST_CASES:
+        metadata = _metadata(case)
+        assert weather_route_key(metadata) == case["expected_route"], case
+        routed = apply_weather_scene_route(metadata)
+        assert routed["scene_route"] == case["expected_route"], case
+        assert routed["scene_family"] in WEATHER_SCENE_ROUTES[case["expected_route"]], case
+
+
+def calm_days_are_not_forced_to_open_beach() -> None:
+    calm_route = WEATHER_SCENE_ROUTES["calm"]
+    assert scene_macro_family(calm_route[0]) == "promenade_urban"
+    assert scene_macro_family(calm_route[1]) == "forest_road"
+    assert scene_macro_family(calm_route[2]) == "lagoon"
+    assert scene_macro_family(calm_route[3]) == "promenade_urban"
+
+
+def strong_wind_days_prioritize_breakwater_cliff_overlook() -> None:
+    route = WEATHER_SCENE_ROUTES["strong_wind"]
+    assert route[:3] == (
+        "baltiysk_breakwater",
+        "svetlogorsk_cliff_coast",
+        "elevated_baltic_overlook",
+    )
+
+
+def two_open_beaches_in_five_block_another_open_beach() -> None:
+    history = [
+        {"date": "2026-08-03", "scene_family": "curonian_spit_dunes", "composition": "c1"},
+        {"date": "2026-08-04", "scene_family": "pine_forest_sea_path", "composition": "c2"},
+        {"date": "2026-08-05", "scene_family": "yantarny_wide_beach", "composition": "c3"},
+        {"date": "2026-08-06", "scene_family": "zelenogradsk_promenade", "composition": "c4"},
+        {"date": "2026-08-07", "scene_family": "quiet_lagoon_coast", "composition": "c5"},
+    ]
+    reason, _ = scene_policy_rejection(
+        history,
+        scene_family="stormy_open_baltic",
+        composition="fresh-composition",
+    )
+    assert reason == "scene_macro_cooldown"
+
+
+def previous_three_scenes_and_four_compositions_are_hard() -> None:
+    history = [
+        {"date": "2026-08-04", "scene_family": "curonian_spit_dunes", "composition": "c1"},
+        {"date": "2026-08-05", "scene_family": "pine_forest_sea_path", "composition": "c2"},
+        {"date": "2026-08-06", "scene_family": "zelenogradsk_promenade", "composition": "c3"},
+        {"date": "2026-08-07", "scene_family": "quiet_lagoon_coast", "composition": "c4"},
+    ]
+    scene_reason, _ = scene_policy_rejection(
+        history,
+        scene_family="quiet_lagoon_coast",
+        composition="fresh",
+    )
+    composition_reason, _ = scene_policy_rejection(
+        history,
+        scene_family="baltiysk_breakwater",
+        composition="c1",
+    )
+    assert scene_reason == "scene_cooldown"
+    assert composition_reason == "composition_cooldown"
+
+
+TESTS = [
+    all_august_cases_use_summer_green,
+    august_weather_routes_match_real_regimes,
+    calm_days_are_not_forced_to_open_beach,
+    strong_wind_days_prioritize_breakwater_cliff_overlook,
+    two_open_beaches_in_five_block_another_open_beach,
+    previous_three_scenes_and_four_compositions_are_hard,
+]
+
+
+def main() -> None:
+    for test in TESTS:
+        test()
+        print(f"PASS: {test.__name__}")
+    print(f"OK: {len(TESTS)} KLD August 2026 visual regressions passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_kld_visual_decision_policy.py
+++ b/tools/test_kld_visual_decision_policy.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Offline regressions for KLD visual decision policy v3."""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from kld_image_first import _visual_decision  # noqa: E402
+from kld_visual_policy import (  # noqa: E402
+    KLD_VISUAL_POLICY_VERSION,
+    WEATHER_SCENE_ROUTES,
+    apply_weather_scene_route,
+    finalize_kld_provider_prompt,
+    scene_policy_rejection,
+    seasonal_guard_label,
+    weather_route_key,
+)
+
+
+def _metadata(**overrides):
+    data = {
+        "forecast_date": "2026-08-08",
+        "target_date": "2026-08-08",
+        "post_type": "morning",
+        "prompt_version": "v6+" + KLD_VISUAL_POLICY_VERSION,
+        "scene_family": "curonian_spit_dunes",
+        "scene_text": "Curonian Spit dunes",
+        "composition": "wide diagonal shoreline composition",
+        "weather_scenario": "cloudy",
+        "wind_gust_category": "calm_to_breezy",
+        "visibility_condition": "clear",
+        "variation_attempt": "0",
+    }
+    data.update(overrides)
+    return data
+
+
+def fog_routes_to_low_visibility_geography() -> None:
+    metadata = _metadata(visibility_condition="mist")
+    routed = apply_weather_scene_route(metadata)
+    assert routed["scene_route"] == "fog_visibility"
+    assert routed["scene_family"] in WEATHER_SCENE_ROUTES["fog_visibility"]
+    assert metadata["scene_family"] == routed["scene_family"]
+
+
+def rain_routes_to_wet_or_sheltered_geography() -> None:
+    metadata = _metadata(weather_scenario="rain", scene_family="yantarny_wide_beach")
+    routed = apply_weather_scene_route(metadata)
+    assert routed["scene_route"] == "rain"
+    assert routed["scene_family"] in WEATHER_SCENE_ROUTES["rain"]
+
+
+def strong_wind_routes_to_exposed_structured_coast() -> None:
+    metadata = _metadata(
+        weather_scenario="cloudy",
+        wind_gust_category="gust_10_14",
+        scene_family="quiet_lagoon_coast",
+    )
+    routed = apply_weather_scene_route(metadata)
+    assert routed["scene_route"] == "strong_wind"
+    assert routed["scene_family"] in WEATHER_SCENE_ROUTES["strong_wind"]
+
+
+def calm_route_keeps_non_beach_options_available() -> None:
+    metadata = _metadata(
+        weather_scenario="cloudy",
+        wind_gust_category="calm_to_breezy",
+        scene_family="pine_forest_sea_path",
+    )
+    routed = apply_weather_scene_route(metadata)
+    assert routed["scene_route"] == "calm"
+    assert routed["scene_family"] == "pine_forest_sea_path"
+    assert WEATHER_SCENE_ROUTES["calm"][:4] == (
+        "kaliningrad_urban_coastal_view",
+        "pine_forest_sea_path",
+        "quiet_lagoon_coast",
+        "zelenogradsk_promenade",
+    )
+
+
+def final_prompt_records_weather_route_and_routed_scene() -> None:
+    metadata = _metadata(
+        weather_scenario="rain",
+        scene_family="yantarny_wide_beach",
+    )
+    prompt = "\n".join(
+        [
+            "Create a photorealistic KLD weather scene.",
+            "Base scene: Baltic coast near Kaliningrad, dunes, pines, promenade, sea horizon.",
+            "Controlled composition: legacy beach lock.",
+            "Text restrictions: no text.",
+        ]
+    )
+    finalized = finalize_kld_provider_prompt(prompt, metadata=metadata, date_key="2026-08-08")
+    assert "Weather scene route: rain." in finalized
+    assert metadata["scene_route"] == "rain"
+    assert f"dominant scene family {metadata['scene_family']}" in finalized
+    assert "Base scene:" not in finalized
+    assert "Controlled composition:" not in finalized
+
+
+def last_four_compositions_are_hard_blocked() -> None:
+    history = [
+        {"date": "2026-08-04", "scene_family": "quiet_lagoon_coast", "composition": "c1"},
+        {"date": "2026-08-05", "scene_family": "zelenogradsk_promenade", "composition": "c2"},
+        {"date": "2026-08-06", "scene_family": "pine_forest_sea_path", "composition": "c3"},
+        {"date": "2026-08-07", "scene_family": "baltiysk_breakwater", "composition": "c4"},
+    ]
+    reason, match = scene_policy_rejection(
+        history,
+        scene_family="kaliningrad_urban_coastal_view",
+        composition="c2",
+    )
+    assert reason == "composition_cooldown"
+    assert match and match["composition"] == "c2"
+
+
+def fifth_previous_composition_is_allowed() -> None:
+    history = [
+        {"date": "2026-08-03", "scene_family": "svetlogorsk_cliff_coast", "composition": "old"},
+        {"date": "2026-08-04", "scene_family": "quiet_lagoon_coast", "composition": "c1"},
+        {"date": "2026-08-05", "scene_family": "zelenogradsk_promenade", "composition": "c2"},
+        {"date": "2026-08-06", "scene_family": "pine_forest_sea_path", "composition": "c3"},
+        {"date": "2026-08-07", "scene_family": "baltiysk_breakwater", "composition": "c4"},
+    ]
+    reason, _ = scene_policy_rejection(
+        history,
+        scene_family="kaliningrad_urban_coastal_view",
+        composition="old",
+    )
+    assert reason == ""
+
+
+def visual_decision_is_single_readable_summary() -> None:
+    result = {
+        "backend": "stable_horde",
+        "selected_scene_family": "baltiysk_breakwater",
+        "selected_composition": "breakwater perspective line",
+        "dedup_reason": "accepted",
+        "dedup_distance": 21,
+        "fallback_reason": "provider_failure",
+        "visual_policy_version": KLD_VISUAL_POLICY_VERSION,
+        "telegram_image_sent": True,
+    }
+    prompt_metadata = {
+        "visual_policy_version": KLD_VISUAL_POLICY_VERSION,
+        "metadata": {
+            "forecast_date": "2026-08-08",
+            "target_date": "2026-08-08",
+            "weather_scenario": "cloudy",
+            "visibility_condition": "clear",
+            "wind_gust_category": "gust_10_14",
+            "scene_route": "strong_wind",
+        },
+    }
+    decision = _visual_decision(result, prompt_metadata, mode="morning")
+    assert decision["backend"] == "stable_horde"
+    assert decision["weather_main"] == "cloudy"
+    assert decision["scene_route"] == "strong_wind"
+    assert decision["seasonal_guard"] == "summer_green"
+    assert decision["scene_family"] == "baltiysk_breakwater"
+    assert decision["scene_macro_family"] == "breakwater_harbour"
+    assert decision["composition"] == "breakwater perspective line"
+    assert decision["content_guard"] == {"valid": True, "reason": "accepted"}
+    assert decision["dedup"] == {"reason": "accepted", "distance": 21}
+    assert decision["published"] is True
+
+
+def season_label_tracks_target_date() -> None:
+    assert seasonal_guard_label("2026-06-01") == "summer_green"
+    assert seasonal_guard_label("2026-08-31") == "summer_green"
+    assert seasonal_guard_label("2026-09-01") == "seasonal_default"
+
+
+TESTS = [
+    fog_routes_to_low_visibility_geography,
+    rain_routes_to_wet_or_sheltered_geography,
+    strong_wind_routes_to_exposed_structured_coast,
+    calm_route_keeps_non_beach_options_available,
+    final_prompt_records_weather_route_and_routed_scene,
+    last_four_compositions_are_hard_blocked,
+    fifth_previous_composition_is_allowed,
+    visual_decision_is_single_readable_summary,
+    season_label_tracks_target_date,
+]
+
+
+def main() -> None:
+    for test in TESTS:
+        test()
+        print(f"PASS: {test.__name__}")
+    print(f"OK: {len(TESTS)} KLD visual decision policy checks passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Scope
Complete the remaining KLD visual decision-policy work before wiring the full offline suite into PR CI.

### What changes
- visual policy version moves to `kld_visual_policy_v3`;
- adds weather-aware scene routing for fog/reduced visibility, rain/drizzle, storm, strong wind and calm conditions;
- keeps the selected scene metadata aligned with the actual provider prompt so cache/history/dedup describe the scene that was requested;
- makes the last **4 compositions** a hard final invariant, alongside the existing hard last-3 scene-family cooldown and open-beach/dunes quota (`<=2/5`);
- adds a single `visual_decision` summary to final `image_result.json` with backend, weather, visibility, gust category, route, seasonal guard, scene, macro-family, composition, content-guard status, dedup result, fallback reason and published state;
- adds permanent offline regressions for the 01–08 Aug 2026 KLD weather regimes that exposed the repetitive beach visual problem.

### August regression policy
The Aug 1–8 fixture asserts policy invariants rather than preserving old provider JPGs: summer-green seasonality, rain/drizzle routing, calm non-beach options, strong-wind breakwater/cliff/overlook preference, hard last-3 scenes, hard last-4 compositions and open-beach <=2/5.

### Safety
- no Telegram calls;
- no Pollinations or Stable Horde calls;
- no production workflow dispatch;
- no Schumann/Safecast/data files changed;
- no FX or text/editor logic changed;
- no force push.

### Validation
New offline regression scripts:
- `tools/test_kld_visual_decision_policy.py`
- `tools/test_kld_august_2026_visual_regression.py`

The repository's current automatic PR workflow still runs only daily/FX dry-runs. The new focused visual tests are committed here but are not yet wired into automatic PR CI. That is intentionally reserved for the following CI-only PR (#21 in the implementation sequence).

Base SHA at branch creation: `0d354d48c584a774c05bed3be8c9a872b578bdec`.