### PR TITLE
fix: enforce Kaliningrad visual geography

### DIFF
--- a/imagegen.py
+++ b/imagegen.py
@@ -84,6 +84,15 @@ def stable_horde_enabled() -> bool:
     return os.getenv("KLD_STABLE_HORDE_ENABLED", "1").strip().lower() in {"1", "true", "yes", "on"}
 
 
+def compose_stable_horde_prompt(positive_prompt: str, negative_prompt: str = "") -> str:
+    """Use AI Horde's supported positive/negative ``###`` prompt boundary."""
+    positive = " ".join(str(positive_prompt or "").split())
+    negative = " ".join(str(negative_prompt or "").split())
+    if not positive:
+        raise ValueError("imagegen: empty Stable Horde positive prompt")
+    return f"{positive} ### {negative}" if negative else positive
+
+
 def _exception_attempt(attempt: int, exc: Exception) -> dict[str, Any]:
     return {
         "attempt": attempt,
@@ -615,8 +624,10 @@ def generate_kld_stable_horde_image(*args, **kwargs) -> str:
             attempts=[],
         )
 
+    negative_prompt = str(kwargs.get("negative_prompt") or "").strip()
     prompt, style_name, out_path, extra = _extract_args(args, kwargs)
-    final_prompt = (prompt.strip() + (f" style:{style_name}" if style_name else "")).strip()
+    positive_prompt = (prompt.strip() + (f" style:{style_name}" if style_name else "")).strip()
+    final_prompt = compose_stable_horde_prompt(positive_prompt, negative_prompt)
     seed = extra.get("seed")
     if seed is None:
         seed = _sha_seed(final_prompt)

--- a/kld_image_content_guard.py
+++ b/kld_image_content_guard.py
@@ -2,14 +2,18 @@
 # -*- coding: utf-8 -*-
 """Conservative offline content guard for provider-generated KLD images.
 
-This gate is deliberately narrow.  It rejects only high-confidence screen/UI
-outputs that are technically valid image files but unsuitable for a weather
-channel.  Geographic relevance is primarily enforced by prompt and scene
-policy; broad image-semantic classification is intentionally not guessed here.
+This gate is deliberately conservative. It rejects high-confidence screen/UI
+outputs plus two narrow geographic failures that can be established from image
+structure without an external vision service: a dry golden steppe replacing
+living summer vegetation, and a land-only frame for a scene whose defining
+feature is open Baltic water. Sand, wood, reeds and autumn colour are protected
+by season, scene and water-context checks rather than colour alone.
 """
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
+import colorsys
+import datetime as dt
 import logging
 from pathlib import Path
 from typing import Any
@@ -30,6 +34,30 @@ _TOP_END_ROW = 32
 _BODY_START_ROW = 48
 _BODY_END_ROW = 254
 
+_OPEN_BALTIC_SCENES = frozenset(
+    {
+        "curonian_spit_dunes",
+        "svetlogorsk_cliff_coast",
+        "zelenogradsk_promenade",
+        "baltiysk_breakwater",
+        "yantarny_wide_beach",
+        "stormy_open_baltic",
+        "elevated_baltic_overlook",
+        "kaliningrad_urban_coastal_view",
+    }
+)
+_LIVING_VEGETATION_SCENES = frozenset(
+    {
+        "curonian_spit_dunes",
+        "svetlogorsk_cliff_coast",
+        "yantarny_wide_beach",
+        "pine_forest_sea_path",
+        "quiet_lagoon_coast",
+        "elevated_baltic_overlook",
+        "rainy_coastal_road",
+    }
+)
+
 
 @dataclass(frozen=True)
 class KldImageContentVerdict:
@@ -39,6 +67,11 @@ class KldImageContentVerdict:
     body_edge_density: float
     top_to_body_edge_ratio: float
     dense_top_rows: int
+    lower_gold_fraction: float
+    lower_green_fraction: float
+    water_band_fraction: float
+    water_rows: int
+    dense_gold_rows: int
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -65,7 +98,99 @@ def _edge_metrics(image: "Image.Image") -> tuple[float, float, float, int]:
     return top, body, ratio, dense_top_rows
 
 
-def inspect_kld_provider_image(path: str | Path) -> KldImageContentVerdict:
+def _semantic_colour_metrics(image: "Image.Image") -> tuple[float, float, float, int, int]:
+    sample_size = 160
+    sample = image.convert("RGB").resize(
+        (sample_size, sample_size), Image.Resampling.BILINEAR
+    )
+    rows = [
+        list(sample.crop((0, y, sample_size, y + 1)).getdata())
+        for y in range(sample_size)
+    ]
+    lower_start = int(sample_size * 0.48)
+    lower_end = int(sample_size * 0.98)
+    water_start = int(sample_size * 0.43)
+    water_end = int(sample_size * 0.80)
+    gold = 0
+    green = 0
+    lower_total = max(1, (lower_end - lower_start) * sample_size)
+    water = 0
+    water_total = max(1, (water_end - water_start) * sample_size)
+    water_rows = 0
+    dense_gold_rows = 0
+
+    for y, row in enumerate(rows):
+        row_gold = 0
+        row_water = 0
+        for red, green_channel, blue in row:
+            hue, saturation, value = colorsys.rgb_to_hsv(
+                red / 255.0,
+                green_channel / 255.0,
+                blue / 255.0,
+            )
+            is_green = (
+                0.19 <= hue <= 0.46
+                and saturation >= 0.18
+                and 0.12 <= value <= 0.88
+                and green_channel >= red * 0.82
+                and green_channel >= blue * 0.80
+            )
+            is_gold = (
+                0.07 <= hue <= 0.18
+                and saturation >= 0.20
+                and 0.30 <= value <= 0.92
+                and red >= green_channel * 0.95
+                and green_channel >= blue * 1.12
+            )
+            blue_water = (
+                0.48 <= hue <= 0.72
+                and saturation >= 0.12
+                and 0.15 <= value <= 0.90
+            )
+            cool_grey_water = (
+                saturation < 0.20
+                and 0.24 <= value <= 0.78
+                and blue >= red * 1.03
+                and green_channel >= red * 0.98
+            )
+            if lower_start <= y < lower_end:
+                if is_green:
+                    green += 1
+                if is_gold:
+                    gold += 1
+                    row_gold += 1
+            if water_start <= y < water_end and (blue_water or cool_grey_water):
+                water += 1
+                row_water += 1
+        if lower_start <= y < lower_end and row_gold / sample_size >= 0.42:
+            dense_gold_rows += 1
+        if water_start <= y < water_end and row_water / sample_size >= 0.32:
+            water_rows += 1
+
+    return (
+        gold / lower_total,
+        green / lower_total,
+        water / water_total,
+        water_rows,
+        dense_gold_rows,
+    )
+
+
+def _is_summer(value: str | dt.date | None) -> bool:
+    if isinstance(value, dt.date):
+        return value.month in {6, 7, 8}
+    try:
+        return dt.date.fromisoformat(str(value or "")[:10]).month in {6, 7, 8}
+    except ValueError:
+        return False
+
+
+def inspect_kld_provider_image(
+    path: str | Path,
+    *,
+    scene_family: str = "",
+    target_date: str | dt.date | None = None,
+) -> KldImageContentVerdict:
     """Return a conservative verdict for an AI-provider image."""
     if Image is None:
         return KldImageContentVerdict(
@@ -75,12 +200,18 @@ def inspect_kld_provider_image(path: str | Path) -> KldImageContentVerdict:
             body_edge_density=0.0,
             top_to_body_edge_ratio=0.0,
             dense_top_rows=0,
+            lower_gold_fraction=0.0,
+            lower_green_fraction=0.0,
+            water_band_fraction=0.0,
+            water_rows=0,
+            dense_gold_rows=0,
         )
 
     try:
         with Image.open(path) as opened:
             image = opened.convert("RGB")
             top, body, ratio, dense_top_rows = _edge_metrics(image)
+            gold, green, water, water_rows, dense_gold_rows = _semantic_colour_metrics(image)
     except Exception as exc:
         LOG.warning("KLD provider content inspection failed: %s", exc)
         return KldImageContentVerdict(
@@ -90,6 +221,11 @@ def inspect_kld_provider_image(path: str | Path) -> KldImageContentVerdict:
             body_edge_density=0.0,
             top_to_body_edge_ratio=0.0,
             dense_top_rows=0,
+            lower_gold_fraction=0.0,
+            lower_green_fraction=0.0,
+            water_band_fraction=0.0,
+            water_rows=0,
+            dense_gold_rows=0,
         )
 
     screenshot_chrome = (
@@ -98,7 +234,29 @@ def inspect_kld_provider_image(path: str | Path) -> KldImageContentVerdict:
         and ratio >= 3.0
         and dense_top_rows >= 5
     )
-    reason = "screen_or_ui_chrome" if screenshot_chrome else "accepted"
+    scene = str(scene_family or "").strip()
+    summer_dry_steppe = (
+        _is_summer(target_date)
+        and scene in _LIVING_VEGETATION_SCENES
+        and gold >= 0.32
+        and green <= 0.07
+        and dense_gold_rows >= 12
+        and (water < 0.10 or water_rows < 4)
+    )
+    required_baltic_missing = (
+        scene in _OPEN_BALTIC_SCENES
+        and water < 0.02
+        and water_rows == 0
+        and (green >= 0.25 or gold >= 0.25)
+    )
+    if screenshot_chrome:
+        reason = "screen_or_ui_chrome"
+    elif summer_dry_steppe:
+        reason = "summer_dry_steppe"
+    elif required_baltic_missing:
+        reason = "required_baltic_missing"
+    else:
+        reason = "accepted"
     return KldImageContentVerdict(
         valid=reason == "accepted",
         reason=reason,
@@ -106,6 +264,11 @@ def inspect_kld_provider_image(path: str | Path) -> KldImageContentVerdict:
         body_edge_density=round(body, 6),
         top_to_body_edge_ratio=round(ratio, 6),
         dense_top_rows=dense_top_rows,
+        lower_gold_fraction=round(gold, 6),
+        lower_green_fraction=round(green, 6),
+        water_band_fraction=round(water, 6),
+        water_rows=water_rows,
+        dense_gold_rows=dense_gold_rows,
     )
 
 

--- a/kld_visual_dedup.py
+++ b/kld_visual_dedup.py
@@ -257,7 +257,11 @@ def evaluate_kld_visual_candidate(
     # Local covers are deterministic cards and are validated semantically by
     # kld_informative_cover.py. The provider content guard is for AI images.
     if str(scene_family or "") != "local_informative_cover":
-        verdict = inspect_kld_provider_image(image_path)
+        verdict = inspect_kld_provider_image(
+            image_path,
+            scene_family=scene_family,
+            target_date=target_date,
+        )
         verdict_payload = verdict.to_dict()
         if not verdict.valid:
             return KldVisualDuplicateResult(

--- a/kld_visual_policy.py
+++ b/kld_visual_policy.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import datetime as dt
 from typing import Any, Mapping, MutableMapping, Sequence
 
-KLD_VISUAL_POLICY_VERSION = "kld_visual_policy_v3"
+KLD_VISUAL_POLICY_VERSION = "kld_visual_policy_v4"
 SUMMER_MONTHS = frozenset({6, 7, 8})
 
 SUMMER_VEGETATION_CUE = (
@@ -61,6 +61,88 @@ _SCENE_TEXT = {
     "kaliningrad_urban_coastal_view": "urban Baltic coastal edge with modest Kaliningrad-region architecture, promenade and sea horizon",
     "rainy_coastal_road": "rain-darkened coastal road near dunes and pines, with the Baltic shoreline visible beyond",
 }
+
+_SCENE_COMPOSITIONS: dict[str, tuple[str, ...]] = {
+    "curonian_spit_dunes": (
+        "wide diagonal shoreline composition",
+        "foreground dune grass with open water behind",
+        "pine-framed side composition",
+        "open horizon with large sky",
+    ),
+    "svetlogorsk_cliff_coast": (
+        "wide diagonal shoreline composition",
+        "low coastal stones leading line",
+        "pine-framed side composition",
+        "elevated overlook panorama",
+        "open horizon with large sky",
+    ),
+    "zelenogradsk_promenade": (
+        "wide diagonal shoreline composition",
+        "promenade railing foreground",
+        "open horizon with large sky",
+    ),
+    "baltiysk_breakwater": (
+        "wide diagonal shoreline composition",
+        "low coastal stones leading line",
+        "open horizon with large sky",
+        "breakwater perspective line",
+    ),
+    "yantarny_wide_beach": (
+        "wide diagonal shoreline composition",
+        "foreground dune grass with open water behind",
+        "open horizon with large sky",
+    ),
+    "pine_forest_sea_path": (
+        "wide diagonal shoreline composition",
+        "foreground dune grass with open water behind",
+        "pine-framed side composition",
+        "open horizon with large sky",
+    ),
+    "stormy_open_baltic": (
+        "wide diagonal shoreline composition",
+        "low coastal stones leading line",
+        "open horizon with large sky",
+    ),
+    "quiet_lagoon_coast": (
+        "wide diagonal shoreline composition",
+        "foreground dune grass with open water behind",
+        "open horizon with large sky",
+    ),
+    "wet_seaside_promenade": (
+        "wide diagonal shoreline composition",
+        "promenade railing foreground",
+        "open horizon with large sky",
+    ),
+    "elevated_baltic_overlook": (
+        "wide diagonal shoreline composition",
+        "pine-framed side composition",
+        "elevated overlook panorama",
+        "open horizon with large sky",
+    ),
+    "kaliningrad_urban_coastal_view": (
+        "wide diagonal shoreline composition",
+        "promenade railing foreground",
+        "open horizon with large sky",
+    ),
+    "rainy_coastal_road": (
+        "wide diagonal shoreline composition",
+        "pine-framed side composition",
+        "open horizon with large sky",
+    ),
+}
+
+_OPEN_BALTIC_SCENES = frozenset(
+    {
+        "curonian_spit_dunes",
+        "svetlogorsk_cliff_coast",
+        "zelenogradsk_promenade",
+        "baltiysk_breakwater",
+        "yantarny_wide_beach",
+        "stormy_open_baltic",
+        "elevated_baltic_overlook",
+        "kaliningrad_urban_coastal_view",
+    }
+)
 
 WEATHER_SCENE_ROUTES: dict[str, tuple[str, ...]] = {
     "fog_visibility": (
@@ -183,6 +265,36 @@ def weather_route_scenes(metadata: Mapping[str, Any]) -> tuple[str, ...]:
     return WEATHER_SCENE_ROUTES[weather_route_key(metadata)]
 
 
+def scene_compositions(scene_family: str) -> tuple[str, ...]:
+    """Return compositions that do not inject foreign objects into a scene."""
+    return _SCENE_COMPOSITIONS.get(
+        str(scene_family or "").strip(),
+        ("wide diagonal shoreline composition", "open horizon with large sky"),
+    )
+
+
+def scene_composition_compatible(scene_family: str, composition: str) -> bool:
+    return str(composition or "").strip() in scene_compositions(scene_family)
+
+
+def apply_scene_composition_policy(metadata: Mapping[str, Any]) -> dict[str, Any]:
+    """Replace an incompatible object-led composition deterministically."""
+    normalized = dict(metadata)
+    scene = str(normalized.get("scene_family") or "").strip()
+    composition = str(normalized.get("composition") or "").strip()
+    allowed = scene_compositions(scene)
+    if composition not in allowed:
+        try:
+            attempt = int(normalized.get("variation_attempt") or 0)
+        except (TypeError, ValueError):
+            attempt = 0
+        offset = sum(ord(char) for char in composition) % len(allowed) if composition else 0
+        normalized["composition"] = allowed[(attempt + offset) % len(allowed)]
+    if isinstance(metadata, MutableMapping):
+        metadata.update(normalized)
+    return normalized
+
+
 def apply_weather_scene_route(metadata: Mapping[str, Any]) -> dict[str, Any]:
     """Bias the final provider scene toward weather-relevant KLD geography.
 
@@ -206,9 +318,90 @@ def apply_weather_scene_route(metadata: Mapping[str, Any]) -> dict[str, Any]:
         routed["scene_family"] = current
         routed["scene_text"] = _SCENE_TEXT[current]
     routed["scene_route"] = route_key
+    routed = apply_scene_composition_policy(routed)
     if isinstance(metadata, MutableMapping):
         metadata.update(routed)
     return routed
+
+
+def build_stable_horde_prompt_parts(
+    metadata: Mapping[str, Any],
+) -> tuple[str, str]:
+    """Build a short KLD-first positive prompt and a separate Horde negative prompt."""
+    target = parse_date_key(metadata.get("target_date") or metadata.get("forecast_date"))
+    month_names = {
+        1: "January winter",
+        2: "February winter",
+        3: "March spring",
+        4: "April spring",
+        5: "May spring",
+        6: "June summer",
+        7: "July summer",
+        8: "August summer",
+        9: "September autumn",
+        10: "October autumn",
+        11: "November autumn",
+        12: "December winter",
+    }
+    season = month_names.get(target.month if target else 0, "realistic northern Baltic season")
+    summer = bool(target and target.month in SUMMER_MONTHS)
+    scene = str(metadata.get("scene_family") or "unknown")
+    scene_text = str(metadata.get("scene_text") or "real Kaliningrad-region coast")
+    composition = str(metadata.get("composition") or "natural coastal composition")
+    weather = str(metadata.get("weather_scenario") or "natural coastal weather")
+    visibility = str(metadata.get("visibility_condition") or "clear")
+    gust = str(metadata.get("wind_gust_category") or "wind_unknown")
+    post_type = str(metadata.get("post_type") or "daily")
+    lunar = str(metadata.get("lunar_phase") or "unknown")
+
+    opening = f"Kaliningrad region, Baltic Sea coast, {season}."
+    if summer:
+        opening += " Any visible living coastal vegetation is lush fresh natural green."
+    positive_parts = [
+        opening,
+        "Photorealistic northern Baltic weather photograph with restrained natural colour.",
+        f"Selected scene: {scene_text}.",
+        f"Composition: {composition}.",
+        f"Weather: {weather}; visibility: {visibility}; wind: {gust}; {post_type} light.",
+    ]
+    if scene in _OPEN_BALTIC_SCENES:
+        positive_parts.append("Open Baltic water and a readable sea horizon are clearly present.")
+    if lunar not in {"", "unknown", "none"}:
+        positive_parts.append(f"Lunar phase: {lunar}.")
+
+    negative_parts = [
+        "unrelated geography",
+        "arid steppe",
+        "savanna",
+        "Mediterranean dry landscape",
+        "tropical vegetation",
+        "map",
+        "satellite image",
+        "screenshot",
+        "browser interface",
+        "app interface",
+        "UI chrome",
+        "dashboard",
+        "poster",
+        "infographic",
+        "text overlay",
+        "watermark",
+    ]
+    if summer:
+        negative_parts[1:1] = [
+            "dry yellow living grass",
+            "golden grass field",
+            "straw-coloured living vegetation",
+        ]
+    if scene != "baltiysk_breakwater":
+        negative_parts.extend(("breakwater", "working harbour"))
+    if scene not in {
+        "zelenogradsk_promenade",
+        "wet_seaside_promenade",
+        "kaliningrad_urban_coastal_view",
+    }:
+        negative_parts.extend(("promenade railing", "urban street"))
+    return " ".join(positive_parts), ", ".join(negative_parts)
 
 
 def recent_real_scene_entries(history: Sequence[Mapping[str, Any]], *, limit: int = 5) -> list[Mapping[str, Any]]:
@@ -360,13 +553,17 @@ __all__ = [
     "SUMMER_MONTHS",
     "SUMMER_VEGETATION_CUE",
     "WEATHER_SCENE_ROUTES",
+    "apply_scene_composition_policy",
     "apply_summer_vegetation_guard",
     "apply_weather_scene_route",
     "build_scene_contract",
+    "build_stable_horde_prompt_parts",
     "finalize_kld_provider_prompt",
     "parse_date_key",
     "recent_real_scene_entries",
     "scene_macro_family",
+    "scene_composition_compatible",
+    "scene_compositions",
     "scene_policy_rejection",
     "seasonal_guard_label",
     "weather_route_key",

--- a/tools/kld_visual_fixture_image.py
+++ b/tools/kld_visual_fixture_image.py
@@ -53,6 +53,7 @@ from kld_visual_dedup import (  # noqa: E402
 from kld_visual_policy import (  # noqa: E402
     KLD_VISUAL_POLICY_VERSION,
     apply_weather_scene_route,
+    build_stable_horde_prompt_parts,
     finalize_kld_provider_prompt,
 )
 from visual_context_kld import build_visual_context  # noqa: E402
@@ -492,12 +493,13 @@ def _provider_attempt_payload(
     result: str,
     diagnostics: Mapping[str, Any] | None = None,
     error: Mapping[str, Any] | None = None,
+    prompt_contract: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     metadata = candidate["metadata"]
     diagnostics = dict(diagnostics or {})
     error = dict(error or {})
     http_attempts = list(diagnostics.get("attempts") or error.get("attempts") or [])
-    return {
+    payload = {
         "backend": backend,
         "variation_attempt": int(candidate.get("variation_attempt") or 0),
         "scene_family": str(metadata.get("scene_family") or ""),
@@ -513,6 +515,9 @@ def _provider_attempt_payload(
         ),
         "http_attempts": http_attempts,
     }
+    if prompt_contract:
+        payload["prompt_contract"] = dict(prompt_contract)
+    return payload
 
 
 def _rejection_fallback_reason(reasons: list[str]) -> str:
@@ -589,12 +594,27 @@ def execute_image_delivery(
             provider_candidates = []
         for candidate in provider_candidates:
             metadata = candidate["metadata"]
-            try:
-                img_path = generator(
-                    prompt=candidate["image_prompt"],
-                    style_name=candidate["style_name"],
-                    seed=_seed_from_cache_key(candidate["cache_key"]),
+            generation_kwargs: dict[str, Any] = {
+                "prompt": candidate["image_prompt"],
+                "style_name": candidate["style_name"],
+                "seed": _seed_from_cache_key(candidate["cache_key"]),
+            }
+            prompt_contract: dict[str, Any] = {"profile": "full_provider_prompt"}
+            if backend == "stable_horde":
+                positive_prompt, negative_prompt = build_stable_horde_prompt_parts(metadata)
+                generation_kwargs.update(
+                    prompt=positive_prompt,
+                    style_name="",
+                    negative_prompt=negative_prompt,
                 )
+                prompt_contract = {
+                    "profile": "kld_short_positive_negative",
+                    "positive_words": len(positive_prompt.split()),
+                    "negative_words": len(negative_prompt.split()),
+                    "negative_separated": True,
+                }
+            try:
+                img_path = generator(**generation_kwargs)
             except Exception as exc:
                 provider_failed = True
                 error = _error_payload(exc)
@@ -612,6 +632,7 @@ def execute_image_delivery(
                     candidate=candidate,
                     result="failed",
                     error=error,
+                    prompt_contract=prompt_contract,
                 )
                 outcome["provider_attempts"].append(attempt_payload)
                 outcome["http_attempt_count"] += attempt_payload["http_attempt_count"]
@@ -627,6 +648,7 @@ def execute_image_delivery(
                 candidate=candidate,
                 result="generated",
                 diagnostics=diagnostics,
+                prompt_contract=prompt_contract,
             )
             outcome["provider_attempts"].append(attempt_payload)
             outcome["http_attempt_count"] += attempt_payload["http_attempt_count"]

--- a/tools/test_kld_image_content_guard.py
+++ b/tools/test_kld_image_content_guard.py
@@ -60,6 +60,33 @@ def _write_landscape_like(path: Path) -> bool:
     return True
 
 
+def _write_layered_scene(
+    path: Path,
+    *,
+    sky: tuple[int, int, int],
+    water: tuple[int, int, int] | None,
+    ground: tuple[int, int, int],
+    water_top: int = 210,
+    ground_top: int = 370,
+) -> bool:
+    Image, ImageDraw = _require_pillow()
+    if Image is None:
+        return False
+    image = Image.new("RGB", (512, 512), color=sky)
+    draw = ImageDraw.Draw(image)
+    if water is not None:
+        draw.rectangle((0, water_top, 511, ground_top - 1), fill=water)
+        for y in range(water_top + 10, ground_top, 24):
+            draw.line((0, y, 511, y), fill=tuple(min(255, value + 12) for value in water), width=2)
+    else:
+        ground_top = water_top
+    draw.rectangle((0, ground_top, 511, 511), fill=ground)
+    for y in range(ground_top + 8, 512, 20):
+        draw.line((0, y, 511, y), fill=tuple(max(0, value - 10) for value in ground), width=2)
+    image.save(path)
+    return True
+
+
 def kld_guard_rejects_dense_top_ui_band() -> None:
     root = _tmpdir()
     try:
@@ -83,6 +110,120 @@ def kld_guard_accepts_simple_landscape() -> None:
         verdict = inspect_kld_provider_image(path)
         assert verdict.valid is True
         assert verdict.reason == "accepted"
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def kld_guard_rejects_summer_dry_steppe_without_baltic() -> None:
+    root = _tmpdir()
+    try:
+        path = root / "dry-field.png"
+        if not _write_layered_scene(
+            path,
+            sky=(150, 181, 205),
+            water=None,
+            ground=(184, 148, 62),
+            water_top=190,
+        ):
+            return
+        verdict = inspect_kld_provider_image(
+            path,
+            scene_family="curonian_spit_dunes",
+            target_date="2026-08-09",
+        )
+        assert verdict.valid is False
+        assert verdict.reason == "summer_dry_steppe"
+        assert verdict.lower_gold_fraction >= 0.32
+        assert verdict.lower_green_fraction <= 0.07
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def kld_guard_accepts_green_baltic_coast() -> None:
+    root = _tmpdir()
+    try:
+        path = root / "green-coast.png"
+        if not _write_layered_scene(
+            path,
+            sky=(156, 181, 198),
+            water=(65, 108, 130),
+            ground=(72, 119, 64),
+        ):
+            return
+        verdict = inspect_kld_provider_image(
+            path,
+            scene_family="curonian_spit_dunes",
+            target_date="2026-08-09",
+        )
+        assert verdict.valid is True, verdict
+        assert verdict.water_rows >= 4
+        assert verdict.lower_green_fraction > 0.10
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def kld_guard_accepts_sand_wood_reeds_and_cloudy_baltic() -> None:
+    root = _tmpdir()
+    try:
+        cases = (
+            ("sand", (151, 181, 199), (61, 104, 127), (208, 188, 137), "curonian_spit_dunes"),
+            ("wood", (151, 181, 199), (61, 104, 127), (132, 91, 49), "zelenogradsk_promenade"),
+            ("reeds", (151, 181, 199), (61, 104, 127), (176, 146, 78), "quiet_lagoon_coast"),
+            ("cloudy", (132, 142, 149), (91, 105, 113), (73, 104, 67), "curonian_spit_dunes"),
+        )
+        for name, sky, water, ground, scene in cases:
+            path = root / f"{name}.png"
+            assert _write_layered_scene(path, sky=sky, water=water, ground=ground)
+            verdict = inspect_kld_provider_image(
+                path,
+                scene_family=scene,
+                target_date="2026-08-09",
+            )
+            assert verdict.valid is True, (name, verdict)
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def kld_guard_accepts_autumn_gold_with_baltic() -> None:
+    root = _tmpdir()
+    try:
+        path = root / "autumn.png"
+        if not _write_layered_scene(
+            path,
+            sky=(140, 155, 165),
+            water=(78, 102, 118),
+            ground=(177, 137, 57),
+        ):
+            return
+        verdict = inspect_kld_provider_image(
+            path,
+            scene_family="curonian_spit_dunes",
+            target_date="2026-10-09",
+        )
+        assert verdict.valid is True, verdict
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def kld_guard_rejects_land_only_frame_for_open_baltic_scene() -> None:
+    root = _tmpdir()
+    try:
+        path = root / "inland-meadow.png"
+        if not _write_layered_scene(
+            path,
+            sky=(160, 185, 203),
+            water=None,
+            ground=(69, 122, 65),
+            water_top=200,
+        ):
+            return
+        verdict = inspect_kld_provider_image(
+            path,
+            scene_family="curonian_spit_dunes",
+            target_date="2026-08-09",
+        )
+        assert verdict.valid is False
+        assert verdict.reason == "required_baltic_missing"
     finally:
         shutil.rmtree(root, ignore_errors=True)
 
@@ -137,6 +278,11 @@ def kld_local_cover_bypasses_provider_content_guard() -> None:
 TESTS = [
     kld_guard_rejects_dense_top_ui_band,
     kld_guard_accepts_simple_landscape,
+    kld_guard_rejects_summer_dry_steppe_without_baltic,
+    kld_guard_accepts_green_baltic_coast,
+    kld_guard_accepts_sand_wood_reeds_and_cloudy_baltic,
+    kld_guard_accepts_autumn_gold_with_baltic,
+    kld_guard_rejects_land_only_frame_for_open_baltic_scene,
     kld_dedup_gate_propagates_content_rejection,
     kld_local_cover_bypasses_provider_content_guard,
 ]

--- a/tools/test_kld_image_first.py
+++ b/tools/test_kld_image_first.py
@@ -1224,10 +1224,16 @@ def second_backend_runs_after_pollinations_exhaustion_with_diagnostics() -> None
     with TemporaryDirectory() as tmp:
         root = Path(tmp)
         events: list[str] = []
+        secondary_calls: list[dict[str, object]] = []
+
+        def secondary_generate(**kwargs):
+            secondary_calls.append(dict(kwargs))
+            return _image(root / "horde.png", (55, 95, 145))
+
         outcome = _run_delivery(
             root,
             generate=lambda **kwargs: (_ for _ in ()).throw(ProviderFailure("Pollinations exhausted")),
-            secondary_generate=lambda **kwargs: _image(root / "horde.png", (55, 95, 145)),
+            secondary_generate=secondary_generate,
             provider_diagnostics=lambda backend: {
                 "backend": backend,
                 "http_attempt_count": 4,
@@ -1262,10 +1268,106 @@ def second_backend_runs_after_pollinations_exhaustion_with_diagnostics() -> None
         )
         assert outcome["fallback_reason"] == "provider_failure"
         assert outcome["http_attempt_count"] == 7
+        assert len(secondary_calls) == 1
+        assert str(secondary_calls[0]["prompt"]).startswith(
+            "Kaliningrad region, Baltic Sea coast, July summer."
+        )
+        assert "dry yellow living grass" in str(secondary_calls[0]["negative_prompt"])
+        assert len(str(secondary_calls[0]["prompt"]).split()) < 100
+        assert outcome["provider_attempts"][1]["prompt_contract"] == {
+            "profile": "kld_short_positive_negative",
+            "positive_words": len(str(secondary_calls[0]["prompt"]).split()),
+            "negative_words": len(str(secondary_calls[0]["negative_prompt"]).split()),
+            "negative_separated": True,
+        }
         assert outcome["selected_scene_family"]
         assert outcome["selected_composition"]
         assert outcome["selected_cache_key"]
         assert events == ["photo", "history"]
+
+
+def semantic_rejection_rotates_to_next_candidate() -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        events: list[str] = []
+        generated = 0
+
+        def generate(**kwargs):
+            nonlocal generated
+            generated += 1
+            return _image(root / f"semantic-{generated}.png", (70 + generated, 110, 140))
+
+        evaluated = 0
+
+        def evaluate(path, **kwargs):
+            nonlocal evaluated
+            evaluated += 1
+            if evaluated == 1:
+                return _duplicate(
+                    accepted=False,
+                    reason="content_guard:summer_dry_steppe",
+                    distance=18,
+                )
+            return _duplicate(accepted=True, reason="accepted", distance=20)
+
+        outcome = _run_delivery(
+            root,
+            generate=generate,
+            evaluate=evaluate,
+            cover_renderer=_cover_renderer(events),
+            send_photo=lambda *args, **kwargs: events.append("photo") or 109,
+            record=_record(events),
+        )
+        assert outcome["backend"] == "pollinations"
+        assert outcome["cover_attempted"] is False
+        assert len(outcome["provider_attempts"]) == 2
+        assert outcome["provider_attempts"][0]["dedup_reason"] == (
+            "content_guard:summer_dry_steppe"
+        )
+        assert outcome["provider_attempts"][1]["dedup_reason"] == "accepted"
+        assert outcome["provider_attempts"][0]["scene_family"] != (
+            outcome["provider_attempts"][1]["scene_family"]
+        )
+        assert events == ["photo", "history"]
+
+
+def semantic_rejections_exhaust_to_local_cover() -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        events: list[str] = []
+        generated = 0
+
+        def generate(**kwargs):
+            nonlocal generated
+            generated += 1
+            return _image(root / f"rejected-{generated}.png", (80 + generated, 105, 130))
+
+        def evaluate(path, **kwargs):
+            if str(path).endswith("cover.png"):
+                return _duplicate(accepted=True, reason="accepted", distance=20)
+            return _duplicate(
+                accepted=False,
+                reason="content_guard:required_baltic_missing",
+                distance=20,
+            )
+
+        outcome = _run_delivery(
+            root,
+            generate=generate,
+            evaluate=evaluate,
+            cover_renderer=_cover_renderer(events),
+            send_photo=lambda *args, **kwargs: events.append("photo") or 110,
+            record=_record(events),
+        )
+        assert len(outcome["provider_attempts"]) == 3
+        assert all(
+            item["dedup_reason"] == "content_guard:required_baltic_missing"
+            for item in outcome["provider_attempts"]
+        )
+        assert outcome["fallback_reason"] == "semantic_mismatch"
+        assert outcome["backend"] == "local_informative_cover"
+        assert outcome["local_cover_published"] is True
+        assert events == ["cover", "photo", "history"]
 
 
 def near_duplicate_candidates_are_hard_rejected_and_rotate_scene() -> None:
@@ -1425,8 +1527,10 @@ def stable_horde_backend_has_offline_success_and_url_safety() -> None:
     encoded = base64.b64encode(payload_buffer.getvalue()).decode("ascii")
     original_json_request = imagegen._horde_json_request
     original_enabled = os.environ.get("KLD_STABLE_HORDE_ENABLED")
+    submitted_prompt = ""
 
     def fake_json_request(url: str, *, attempts, stage: str, **kwargs):
+        nonlocal submitted_prompt
         attempts.append(
             {
                 "attempt": len(attempts) + 1,
@@ -1437,6 +1541,7 @@ def stable_horde_backend_has_offline_success_and_url_safety() -> None:
             }
         )
         if stage == "submit":
+            submitted_prompt = str((kwargs.get("payload") or {}).get("prompt") or "")
             return {"id": "offline-job"}
         if stage == "check":
             return {"done": True}
@@ -1449,6 +1554,7 @@ def stable_horde_backend_has_offline_success_and_url_safety() -> None:
             output = imagegen.generate_kld_stable_horde_image(
                 prompt="offline Baltic coast",
                 style_name="test",
+                negative_prompt="dry yellow living grass, screenshot",
                 seed=123,
                 out_path=str(Path(tmp) / "horde.jpg"),
             )
@@ -1458,6 +1564,9 @@ def stable_horde_backend_has_offline_success_and_url_safety() -> None:
         diagnostics = imagegen.get_generation_diagnostics("stable_horde")
         assert diagnostics["result"] == "success"
         assert diagnostics["http_attempt_count"] == 3
+        assert submitted_prompt == (
+            "offline Baltic coast style:test ### dry yellow living grass, screenshot"
+        )
         assert imagegen._public_horde_image_url("http://127.0.0.1/image.png") is False
         assert imagegen._public_horde_image_url("http://localhost/image.png") is False
     finally:
@@ -1494,6 +1603,8 @@ TESTS = [
     local_cover_semantic_validation_blocks_tampering,
     invalid_local_cover_is_not_sent_and_text_remains_nonblocking,
     second_backend_runs_after_pollinations_exhaustion_with_diagnostics,
+    semantic_rejection_rotates_to_next_candidate,
+    semantic_rejections_exhaust_to_local_cover,
     near_duplicate_candidates_are_hard_rejected_and_rotate_scene,
     near_duplicate_local_cover_is_not_published,
     recent_scene_and_composition_cooldown_is_applied,

--- a/tools/test_kld_visual_policy.py
+++ b/tools/test_kld_visual_policy.py
@@ -13,8 +13,11 @@ from image_prompt_kld_morning import build_kld_morning_prompt  # noqa: E402
 from kld_visual_policy import (  # noqa: E402
     PROVIDER_NEGATIVE_GUARD,
     SUMMER_VEGETATION_CUE,
+    apply_scene_composition_policy,
     apply_summer_vegetation_guard,
+    build_stable_horde_prompt_parts,
     build_scene_contract,
+    scene_composition_compatible,
     scene_macro_family,
     scene_policy_rejection,
 )
@@ -105,6 +108,46 @@ def kld_policy_august_morning_prompt_has_no_legacy_beach_lock() -> None:
     assert "Controlled composition:" not in prompt
 
 
+def curonian_spit_cannot_receive_breakwater_objects() -> None:
+    metadata = {
+        "scene_family": "curonian_spit_dunes",
+        "composition": "breakwater perspective line",
+        "variation_attempt": "0",
+    }
+    normalized = apply_scene_composition_policy(metadata)
+    assert normalized["composition"] != "breakwater perspective line"
+    assert scene_composition_compatible(
+        normalized["scene_family"], normalized["composition"]
+    )
+    assert scene_composition_compatible(
+        "baltiysk_breakwater", "breakwater perspective line"
+    )
+
+
+def stable_horde_prompt_is_short_kld_first_and_negative_separate() -> None:
+    positive, negative = build_stable_horde_prompt_parts(
+        {
+            "target_date": "2026-08-09",
+            "post_type": "morning",
+            "scene_family": "curonian_spit_dunes",
+            "scene_text": "Curonian Spit dunes with marram grass and open Baltic water",
+            "composition": "foreground dune grass with open water behind",
+            "weather_scenario": "cloudy",
+            "visibility_condition": "clear",
+            "wind_gust_category": "gust_7_9",
+            "lunar_phase": "waning crescent",
+        }
+    )
+    assert positive.startswith("Kaliningrad region, Baltic Sea coast, August summer.")
+    assert "lush fresh natural green" in positive
+    assert "Open Baltic water" in positive
+    assert len(positive.split()) < 100
+    assert "dry yellow living grass" not in positive
+    assert "dry yellow living grass" in negative
+    assert "breakwater" in negative
+    assert "screenshot" in negative
+
+
 TESTS = [
     kld_policy_august_is_green,
     kld_policy_autumn_does_not_force_summer_green,
@@ -114,6 +157,8 @@ TESTS = [
     kld_policy_open_beach_is_limited_to_two_of_five,
     kld_policy_non_beach_scene_survives_beach_quota,
     kld_policy_august_morning_prompt_has_no_legacy_beach_lock,
+    curonian_spit_cannot_receive_breakwater_objects,
+    stable_horde_prompt_is_short_kld_first_and_negative_separate,
 ]
 
 


### PR DESCRIPTION
## Problem

The KLD visual pipeline could accept a geographically wrong summer image even when the provider ignored explicit green-vegetation and Baltic-scene instructions. The production incident combined an incompatible Curonian Spit/breakwater prompt pair, an overlong Stable Horde prompt, and a content guard that only detected UI screenshots.

## Change

- normalize scene/composition pairs so object-led compositions belong to the selected Kaliningrad scene;
- give Stable Horde a short Kaliningrad/Baltic/season-first positive prompt and a separate `###` negative prompt;
- extend the offline post-generation guard with conservative checks for dry golden steppe in summer and missing Baltic water in sea-defining scenes;
- preserve sand, dunes, wood, dry reeds, cloudy Baltic water and autumn colour;
- keep the existing candidate rotation and validated local informative-cover fallback;
- add focused regressions for prompt separation, scene compatibility, accepted/rejected geography and fallback behavior.

## Impact

Provider order, credentials, workflows, Telegram routing, publication cadence, weather data, post text and FX are unchanged. No image was generated or published while preparing this PR.

## Validation

- `python -m compileall` for the KLD visual pipeline
- complete offline `KLD visual regressions` block: 100 checks in 12 suites
- legacy KLD synthetic contract: 22 checks
- `git diff --check`
- all test processes ran with outbound socket connections blocked
