### PR TITLE
fix: prevent KLD visual allocator deadlock

### DIFF
--- a/kld_visual_dedup.py
+++ b/kld_visual_dedup.py
@@ -248,6 +248,7 @@ def evaluate_kld_visual_candidate(
     history_path: str | Path = KLD_VISUAL_HISTORY_PATH,
     current_date: date | None = None,
     threshold: int = KLD_VISUAL_DHASH_THRESHOLD,
+    allow_composition_cooldown_relaxation: bool = False,
 ) -> KldVisualDuplicateResult:
     current = current_date or _parse_date(target_date) or _parse_date(date_value) or _today()
     history = load_kld_visual_history(history_path)
@@ -318,6 +319,12 @@ def evaluate_kld_visual_candidate(
             scene_family=scene_family,
             composition=composition,
         )
+        if policy_reason == "composition_cooldown" and allow_composition_cooldown_relaxation:
+            policy_reason, policy_match = scene_policy_rejection(
+                history,
+                scene_family=scene_family,
+                composition="",
+            )
         if policy_reason:
             return KldVisualDuplicateResult(
                 accepted=False,

--- a/tools/kld_visual_fixture_image.py
+++ b/tools/kld_visual_fixture_image.py
@@ -55,6 +55,7 @@ from kld_visual_policy import (  # noqa: E402
     apply_weather_scene_route,
     build_stable_horde_prompt_parts,
     finalize_kld_provider_prompt,
+    scene_policy_rejection,
 )
 from visual_context_kld import build_visual_context  # noqa: E402
 from visual_rules import apply_visual_rules, build_prompt_from_cues, to_json  # noqa: E402
@@ -420,10 +421,15 @@ def _select_candidate_attempts(
     blocked_scenes: list[str],
     blocked_compositions: list[str],
     count: int,
+    policy_history: list[Mapping[str, Any]] | None = None,
 ) -> tuple[list[int], list[str]]:
     """Select strict candidates, relaxing only oldest compositions on full exhaustion."""
 
-    def select(effective_blocked_compositions: set[str]) -> list[int]:
+    def select(
+        effective_blocked_compositions: set[str],
+        *,
+        require_hard_policy: bool = False,
+    ) -> list[int]:
         selected: list[int] = []
         used_scenes: set[str] = set()
         used_compositions: set[str] = set()
@@ -434,6 +440,14 @@ def _select_candidate_attempts(
                 continue
             if scene in blocked_scenes or composition in effective_blocked_compositions:
                 continue
+            if require_hard_policy and policy_history is not None:
+                policy_reason, _ = scene_policy_rejection(
+                    policy_history,
+                    scene_family=scene,
+                    composition="",
+                )
+                if policy_reason in {"scene_cooldown", "scene_macro_cooldown"}:
+                    continue
             selected.append(variation_attempt)
             used_scenes.add(scene)
             used_compositions.add(composition)
@@ -446,10 +460,11 @@ def _select_candidate_attempts(
         return selected, []
 
     # _recent_visual_cooldown returns newest -> oldest. Relax the oldest
-    # composition first, and stop at the first depth that restores a candidate.
+    # composition first. Continue only when the current depth yields no
+    # candidate that can pass the hard scene/macro policy.
     for relaxation_depth in range(1, len(blocked_compositions) + 1):
         effective = set(blocked_compositions[:-relaxation_depth])
-        selected = select(effective)
+        selected = select(effective, require_hard_policy=True)
         if selected:
             return selected, list(blocked_compositions[-relaxation_depth:])
     return [], []
@@ -506,6 +521,7 @@ def _candidate_payloads(
         blocked_scenes=blocked_scenes,
         blocked_compositions=blocked_compositions,
         count=count,
+        policy_history=load_kld_visual_history(history_path),
     )
     relaxation_depth = len(relaxed_compositions)
     candidates: list[dict[str, Any]] = []

--- a/tools/kld_visual_fixture_image.py
+++ b/tools/kld_visual_fixture_image.py
@@ -414,6 +414,47 @@ def _recent_visual_cooldown(history_path: Path) -> tuple[list[str], list[str]]:
     return scenes, compositions
 
 
+def _select_candidate_attempts(
+    candidate_metadata: list[tuple[int, Mapping[str, Any]]],
+    *,
+    blocked_scenes: list[str],
+    blocked_compositions: list[str],
+    count: int,
+) -> tuple[list[int], list[str]]:
+    """Select strict candidates, relaxing only oldest compositions on full exhaustion."""
+
+    def select(effective_blocked_compositions: set[str]) -> list[int]:
+        selected: list[int] = []
+        used_scenes: set[str] = set()
+        used_compositions: set[str] = set()
+        for variation_attempt, metadata in candidate_metadata:
+            scene = str(metadata["scene_family"])
+            composition = str(metadata["composition"])
+            if scene in used_scenes or composition in used_compositions:
+                continue
+            if scene in blocked_scenes or composition in effective_blocked_compositions:
+                continue
+            selected.append(variation_attempt)
+            used_scenes.add(scene)
+            used_compositions.add(composition)
+            if len(selected) >= count:
+                break
+        return selected
+
+    selected = select(set(blocked_compositions))
+    if selected or not blocked_compositions:
+        return selected, []
+
+    # _recent_visual_cooldown returns newest -> oldest. Relax the oldest
+    # composition first, and stop at the first depth that restores a candidate.
+    for relaxation_depth in range(1, len(blocked_compositions) + 1):
+        effective = set(blocked_compositions[:-relaxation_depth])
+        selected = select(effective)
+        if selected:
+            return selected, list(blocked_compositions[-relaxation_depth:])
+    return [], []
+
+
 def _candidate_payloads(
     *,
     args: argparse.Namespace,
@@ -460,30 +501,25 @@ def _candidate_payloads(
         apply_weather_scene_route(metadata)
         candidate_metadata.append((index, metadata))
 
-    selected_attempts: list[int] = []
-    used_scenes: set[str] = set()
-    used_compositions: set[str] = set()
-    # Scene and composition cooldowns are both hard invariants. Selection is
-    # evaluated after weather routing so the pool is unique by the exact scene
-    # and composition metadata that will be sent to providers.
-    for variation_attempt, metadata in candidate_metadata:
-        scene = str(metadata["scene_family"])
-        composition = str(metadata["composition"])
-        if scene in used_scenes or composition in used_compositions:
-            continue
-        if scene in blocked_scenes or composition in blocked_compositions:
-            continue
-        selected_attempts.append(variation_attempt)
-        used_scenes.add(scene)
-        used_compositions.add(composition)
-        if len(selected_attempts) >= count:
-            break
-
-    return (
-        [payload_for(attempt) for attempt in selected_attempts[:count]],
-        blocked_scenes,
-        blocked_compositions,
+    selected_attempts, relaxed_compositions = _select_candidate_attempts(
+        candidate_metadata,
+        blocked_scenes=blocked_scenes,
+        blocked_compositions=blocked_compositions,
+        count=count,
     )
+    relaxation_depth = len(relaxed_compositions)
+    candidates: list[dict[str, Any]] = []
+    for attempt in selected_attempts[:count]:
+        candidate = payload_for(attempt)
+        composition = str(candidate["metadata"].get("composition") or "")
+        relaxed = composition in relaxed_compositions
+        candidate["composition_cooldown_relaxed"] = relaxed
+        if relaxed:
+            candidate["composition_cooldown_relaxed_value"] = composition
+            candidate["composition_cooldown_relaxation_depth"] = relaxation_depth
+        candidates.append(candidate)
+
+    return candidates, blocked_scenes, blocked_compositions
 
 
 def _provider_attempt_payload(
@@ -505,6 +541,9 @@ def _provider_attempt_payload(
         "scene_family": str(metadata.get("scene_family") or ""),
         "composition": str(metadata.get("composition") or ""),
         "cache_key": str(candidate.get("cache_key") or ""),
+        "composition_cooldown_relaxed": bool(candidate.get("composition_cooldown_relaxed")),
+        "composition_cooldown_relaxed_value": str(candidate.get("composition_cooldown_relaxed_value") or ""),
+        "composition_cooldown_relaxation_depth": int(candidate.get("composition_cooldown_relaxation_depth") or 0),
         "result": result,
         "exception_type": str(error.get("type") or diagnostics.get("exception_type") or ""),
         "error_message": str(error.get("message") or ""),
@@ -580,6 +619,9 @@ def execute_image_delivery(
             "scene_family": str(candidate["metadata"].get("scene_family") or ""),
             "composition": str(candidate["metadata"].get("composition") or ""),
             "cache_key": str(candidate.get("cache_key") or ""),
+            "composition_cooldown_relaxed": bool(candidate.get("composition_cooldown_relaxed")),
+            "composition_cooldown_relaxed_value": str(candidate.get("composition_cooldown_relaxed_value") or ""),
+            "composition_cooldown_relaxation_depth": int(candidate.get("composition_cooldown_relaxation_depth") or 0),
         }
         for candidate in candidates
     ]
@@ -667,6 +709,7 @@ def execute_image_delivery(
                     composition=metadata["composition"],
                     prompt_version=metadata["prompt_version"],
                     history_path=history_path,
+                    allow_composition_cooldown_relaxation=bool(candidate.get("composition_cooldown_relaxed")),
                 )
             except Exception as exc:
                 provider_failed = True

--- a/tools/test_kld_evening_allocator_policy.py
+++ b/tools/test_kld_evening_allocator_policy.py
@@ -356,6 +356,193 @@ def composition_relaxation_does_not_weaken_other_guards() -> None:
             dedup_module.inspect_kld_provider_image = original_guard
 
 
+def macro_blocked_depth_continues_to_minimal_viable_candidate() -> None:
+    blocked_scenes = [
+        "baltiysk_breakwater",
+        "svetlogorsk_cliff_coast",
+        "zelenogradsk_promenade",
+    ]
+    blocked_compositions = [
+        "wide diagonal shoreline composition",
+        "pine-framed side composition",
+        "open horizon with large sky",
+        "foreground dune grass with open water behind",
+    ]
+    policy_history = [
+        {"date": "2026-08-10", "scene_family": "yantarny_wide_beach", "composition": "wide diagonal shoreline composition"},
+        {"date": "2026-08-11", "scene_family": "curonian_spit_dunes", "composition": "foreground dune grass with open water behind"},
+        {"date": "2026-08-12", "scene_family": "zelenogradsk_promenade", "composition": "open horizon with large sky"},
+        {"date": "2026-08-13", "scene_family": "svetlogorsk_cliff_coast", "composition": "pine-framed side composition"},
+        {"date": "2026-08-14", "scene_family": "baltiysk_breakwater", "composition": "wide diagonal shoreline composition"},
+    ]
+    candidate_metadata = [
+        (10, {"scene_family": "yantarny_wide_beach", "composition": "foreground dune grass with open water behind"}),
+        (11, {"scene_family": "elevated_baltic_overlook", "composition": "open horizon with large sky"}),
+    ]
+
+    strict_only = [
+        attempt
+        for attempt, metadata in candidate_metadata
+        if metadata["scene_family"] not in blocked_scenes
+        and metadata["composition"] not in blocked_compositions
+    ]
+    assert strict_only == []
+
+    depth_one_attempts, depth_one_relaxed = _select_candidate_attempts(
+        candidate_metadata,
+        blocked_scenes=blocked_scenes,
+        blocked_compositions=blocked_compositions,
+        count=3,
+    )
+    assert depth_one_attempts == [10]
+    assert depth_one_relaxed == ["foreground dune grass with open water behind"]
+
+    macro_reason, _ = scene_policy_rejection(
+        policy_history,
+        scene_family="yantarny_wide_beach",
+        composition="",
+    )
+    assert macro_reason == "scene_macro_cooldown"
+
+    attempts, relaxed = _select_candidate_attempts(
+        candidate_metadata,
+        blocked_scenes=blocked_scenes,
+        blocked_compositions=blocked_compositions,
+        count=3,
+        policy_history=policy_history,
+    )
+    assert attempts == [11]
+    assert relaxed == [
+        "open horizon with large sky",
+        "foreground dune grass with open water behind",
+    ]
+    viable_reason, _ = scene_policy_rejection(
+        policy_history,
+        scene_family="elevated_baltic_overlook",
+        composition="",
+    )
+    assert viable_reason == ""
+
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        history_path = root / "history.json"
+        history_path.write_text(json.dumps(policy_history), encoding="utf-8")
+        args = _args(root)
+        initial = build_payload(FIXTURES["storm"], "storm", post_type="evening")
+        candidate = {
+            "variation_attempt": 11,
+            "image_prompt": "offline viable depth-2 prompt",
+            "style_name": "offline-style",
+            "cache_key": "offline-depth-2-cache-key",
+            "metadata": {
+                "forecast_date": "2026-08-15",
+                "target_date": "2026-08-15",
+                "scene_family": "elevated_baltic_overlook",
+                "composition": "open horizon with large sky",
+                "prompt_version": "v6+kld_visual_policy_v4",
+            },
+            "composition_cooldown_relaxed": True,
+            "composition_cooldown_relaxed_value": "open horizon with large sky",
+            "composition_cooldown_relaxation_depth": 2,
+        }
+        events: list[str] = []
+        original_candidate_payloads = fixture_module._candidate_payloads
+        try:
+            fixture_module._candidate_payloads = lambda **kwargs: (
+                [candidate],
+                blocked_scenes,
+                blocked_compositions,
+            )
+
+            def generate(**kwargs):
+                events.append("provider")
+                return _ppm(root / "depth-2.ppm", 132)
+
+            outcome = fixture_module.execute_image_delivery(
+                args=args,
+                message=FIXTURES["storm"],
+                initial_payload=initial,
+                visibility_context=None,
+                history_path=history_path,
+                generate_image=generate,
+                secondary_generate_image=None,
+                evaluate_candidate=lambda *args, **kwargs: _accepted(),
+                cover_renderer=lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("cover not expected")),
+                validate_cover=lambda *args, **kwargs: {"valid": True, "errors": []},
+                send_photo=lambda *args, **kwargs: events.append("photo") or 456,
+                record_publication=lambda **kwargs: events.append("history") or {"sha256": "d" * 64},
+            )
+        finally:
+            fixture_module._candidate_payloads = original_candidate_payloads
+
+        assert events == ["provider", "photo", "history"]
+        assert outcome["candidate_pool"][0]["scene_family"] == "elevated_baltic_overlook"
+        assert outcome["candidate_pool"][0]["composition_cooldown_relaxation_depth"] == 2
+        assert outcome["provider_attempts"][0]["scene_family"] == "elevated_baltic_overlook"
+
+
+def composition_relaxation_keeps_exact_and_macro_guards_hard() -> None:
+    class Verdict:
+        def __init__(self, valid: bool, reason: str = "accepted"):
+            self.valid = valid
+            self.reason = reason
+
+        def to_dict(self):
+            return {"valid": self.valid, "reason": self.reason}
+
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        image_path = Path(_ppm(root / "candidate.ppm", 121))
+        history_path = root / "history.json"
+        original_guard = dedup_module.inspect_kld_provider_image
+        try:
+            dedup_module.inspect_kld_provider_image = lambda *args, **kwargs: Verdict(True)
+            exact_history = [
+                {
+                    "date": "2026-08-14",
+                    "scene_family": "quiet_lagoon_coast",
+                    "composition": "promenade railing foreground",
+                    "sha256": dedup_module.sha256_file(image_path),
+                }
+            ]
+            history_path.write_text(json.dumps(exact_history), encoding="utf-8")
+            exact_blocked = dedup_module.evaluate_kld_visual_candidate(
+                image_path,
+                date_value="2026-08-15",
+                target_date="2026-08-15",
+                post_type="evening",
+                scene_family="elevated_baltic_overlook",
+                composition="open horizon with large sky",
+                prompt_version="test",
+                history_path=history_path,
+                allow_composition_cooldown_relaxation=True,
+            )
+            assert exact_blocked.reason == "exact_duplicate"
+
+            macro_history = [
+                {"date": "2026-08-10", "scene_family": "yantarny_wide_beach", "composition": "wide diagonal shoreline composition"},
+                {"date": "2026-08-11", "scene_family": "curonian_spit_dunes", "composition": "pine-framed side composition"},
+                {"date": "2026-08-12", "scene_family": "zelenogradsk_promenade", "composition": "promenade railing foreground"},
+                {"date": "2026-08-13", "scene_family": "svetlogorsk_cliff_coast", "composition": "elevated overlook panorama"},
+                {"date": "2026-08-14", "scene_family": "baltiysk_breakwater", "composition": "breakwater perspective line"},
+            ]
+            history_path.write_text(json.dumps(macro_history), encoding="utf-8")
+            macro_blocked = dedup_module.evaluate_kld_visual_candidate(
+                image_path,
+                date_value="2026-08-15",
+                target_date="2026-08-15",
+                post_type="evening",
+                scene_family="yantarny_wide_beach",
+                composition="foreground dune grass with open water behind",
+                prompt_version="test",
+                history_path=history_path,
+                allow_composition_cooldown_relaxation=True,
+            )
+            assert macro_blocked.reason == "scene_macro_cooldown"
+        finally:
+            dedup_module.inspect_kld_provider_image = original_guard
+
+
 def secondary_backend_rotates_same_fresh_candidate_pool() -> None:
     class PollinationsFailure(RuntimeError):
         backend = "pollinations"
@@ -434,6 +621,8 @@ TESTS = [
     composition_exhaustion_relaxes_oldest_only,
     relaxed_candidate_reaches_provider_and_marks_final_gate,
     composition_relaxation_does_not_weaken_other_guards,
+    macro_blocked_depth_continues_to_minimal_viable_candidate,
+    composition_relaxation_keeps_exact_and_macro_guards_hard,
     secondary_backend_rotates_same_fresh_candidate_pool,
     final_scene_policy_is_hard_and_reasons_are_explicit,
 ]

--- a/tools/test_kld_evening_allocator_policy.py
+++ b/tools/test_kld_evening_allocator_policy.py
@@ -13,16 +13,19 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+import kld_visual_dedup as dedup_module  # noqa: E402
 from kld_visual_dedup import KldVisualDuplicateResult  # noqa: E402
 from kld_visual_policy import (  # noqa: E402
     KLD_VISUAL_POLICY_VERSION,
     SUMMER_VEGETATION_CUE,
     scene_policy_rejection,
 )
+import tools.kld_visual_fixture_image as fixture_module  # noqa: E402
 from tools.kld_visual_fixture_image import (  # noqa: E402
     FIXTURES,
     _candidate_payloads,
     _rejection_fallback_reason,
+    _select_candidate_attempts,
     build_payload,
     execute_image_delivery,
 )
@@ -126,6 +129,231 @@ def storm_allocator_keeps_last_three_scenes_hard_blocked() -> None:
         assert set(scenes) == {"rainy_coastal_road", "elevated_baltic_overlook"}
         assert set(scene_cooldown) == set(blocked)
         assert not (set(scenes) & set(blocked))
+        assert not any(item.get("composition_cooldown_relaxed") for item in candidates)
+
+
+def composition_exhaustion_relaxes_oldest_only() -> None:
+    blocked_scenes = [
+        "kaliningrad_urban_coastal_view",
+        "quiet_lagoon_coast",
+        "zelenogradsk_promenade",
+    ]
+    blocked_compositions = [
+        "open horizon with large sky",
+        "pine-framed side composition",
+        "foreground dune grass with open water behind",
+        "wide diagonal shoreline composition",
+    ]
+    candidate_metadata = [
+        (0, {"scene_family": blocked_scenes[0], "composition": "promenade railing foreground"}),
+        (1, {"scene_family": blocked_scenes[1], "composition": "open horizon with large sky"}),
+        (2, {"scene_family": blocked_scenes[2], "composition": "promenade railing foreground"}),
+        (3, {"scene_family": "curonian_spit_dunes", "composition": "wide diagonal shoreline composition"}),
+        (4, {"scene_family": "elevated_baltic_overlook", "composition": "pine-framed side composition"}),
+    ]
+
+    strict_attempts, _ = _select_candidate_attempts(
+        candidate_metadata,
+        blocked_scenes=blocked_scenes,
+        blocked_compositions=blocked_compositions,
+        count=3,
+    )
+    assert strict_attempts == [3]
+
+    # Verify that no strict candidate exists before the helper's exhaustion fallback.
+    strict_only = []
+    for attempt, metadata in candidate_metadata:
+        if metadata["scene_family"] in blocked_scenes:
+            continue
+        if metadata["composition"] in blocked_compositions:
+            continue
+        strict_only.append(attempt)
+    assert strict_only == []
+
+    attempts, relaxed = _select_candidate_attempts(
+        candidate_metadata,
+        blocked_scenes=blocked_scenes,
+        blocked_compositions=blocked_compositions,
+        count=3,
+    )
+    assert attempts == [3]
+    assert relaxed == ["wide diagonal shoreline composition"]
+
+
+def relaxed_candidate_reaches_provider_and_marks_final_gate() -> None:
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        history_path = root / "history.json"
+        history_path.write_text("[]", encoding="utf-8")
+        args = _args(root)
+        initial = build_payload(FIXTURES["storm"], "storm", post_type="evening")
+        candidate = {
+            "variation_attempt": 17,
+            "image_prompt": "offline prompt",
+            "style_name": "offline-style",
+            "cache_key": "offline-cache-key",
+            "metadata": {
+                "forecast_date": "2026-08-15",
+                "target_date": "2026-08-15",
+                "scene_family": "rainy_coastal_road",
+                "composition": "wide diagonal shoreline composition",
+                "prompt_version": "v6+kld_visual_policy_v4",
+            },
+            "composition_cooldown_relaxed": True,
+            "composition_cooldown_relaxed_value": "wide diagonal shoreline composition",
+            "composition_cooldown_relaxation_depth": 1,
+        }
+        events: list[str] = []
+        captured: dict[str, object] = {}
+        original_candidate_payloads = fixture_module._candidate_payloads
+        try:
+            fixture_module._candidate_payloads = lambda **kwargs: (
+                [candidate],
+                ["zelenogradsk_promenade", "quiet_lagoon_coast", "kaliningrad_urban_coastal_view"],
+                [
+                    "open horizon with large sky",
+                    "pine-framed side composition",
+                    "foreground dune grass with open water behind",
+                    "wide diagonal shoreline composition",
+                ],
+            )
+
+            def generate(**kwargs):
+                events.append("provider")
+                return _ppm(root / "candidate.ppm")
+
+            def evaluate(path, **kwargs):
+                captured.update(kwargs)
+                return _accepted()
+
+            outcome = fixture_module.execute_image_delivery(
+                args=args,
+                message=FIXTURES["storm"],
+                initial_payload=initial,
+                visibility_context=None,
+                history_path=history_path,
+                generate_image=generate,
+                secondary_generate_image=None,
+                evaluate_candidate=evaluate,
+                cover_renderer=lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("cover not expected")),
+                validate_cover=lambda *args, **kwargs: {"valid": True, "errors": []},
+                send_photo=lambda *args, **kwargs: events.append("photo") or 321,
+                record_publication=lambda **kwargs: events.append("history") or {"sha256": "c" * 64},
+            )
+        finally:
+            fixture_module._candidate_payloads = original_candidate_payloads
+
+        assert events == ["provider", "photo", "history"]
+        assert outcome["provider_attempts"]
+        assert outcome["candidate_pool"][0]["composition_cooldown_relaxed"] is True
+        assert outcome["provider_attempts"][0]["composition_cooldown_relaxed"] is True
+        assert captured["allow_composition_cooldown_relaxation"] is True
+
+
+def composition_relaxation_does_not_weaken_other_guards() -> None:
+    class Verdict:
+        def __init__(self, valid: bool, reason: str = "accepted"):
+            self.valid = valid
+            self.reason = reason
+
+        def to_dict(self):
+            return {"valid": self.valid, "reason": self.reason}
+
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        image_path = Path(_ppm(root / "candidate.ppm", 111))
+        history_path = root / "history.json"
+        original_guard = dedup_module.inspect_kld_provider_image
+        try:
+            dedup_module.inspect_kld_provider_image = lambda *args, **kwargs: Verdict(True)
+            composition_history = [
+                {"date": "2026-08-11", "scene_family": "quiet_lagoon_coast", "composition": "wide diagonal shoreline composition"},
+                {"date": "2026-08-12", "scene_family": "zelenogradsk_promenade", "composition": "promenade railing foreground"},
+                {"date": "2026-08-13", "scene_family": "baltiysk_breakwater", "composition": "breakwater perspective line"},
+                {"date": "2026-08-14", "scene_family": "svetlogorsk_cliff_coast", "composition": "elevated overlook panorama"},
+            ]
+            history_path.write_text(json.dumps(composition_history), encoding="utf-8")
+            strict = dedup_module.evaluate_kld_visual_candidate(
+                image_path,
+                date_value="2026-08-15",
+                target_date="2026-08-15",
+                post_type="evening",
+                scene_family="rainy_coastal_road",
+                composition="wide diagonal shoreline composition",
+                prompt_version="test",
+                history_path=history_path,
+            )
+            assert strict.reason == "composition_cooldown"
+            relaxed = dedup_module.evaluate_kld_visual_candidate(
+                image_path,
+                date_value="2026-08-15",
+                target_date="2026-08-15",
+                post_type="evening",
+                scene_family="rainy_coastal_road",
+                composition="wide diagonal shoreline composition",
+                prompt_version="test",
+                history_path=history_path,
+                allow_composition_cooldown_relaxation=True,
+            )
+            assert relaxed.accepted is True
+
+            scene_history = composition_history + [
+                {"date": "2026-08-15", "scene_family": "rainy_coastal_road", "composition": "open horizon with large sky"}
+            ]
+            history_path.write_text(json.dumps(scene_history), encoding="utf-8")
+            scene_blocked = dedup_module.evaluate_kld_visual_candidate(
+                image_path,
+                date_value="2026-08-15",
+                target_date="2026-08-15",
+                post_type="evening",
+                scene_family="rainy_coastal_road",
+                composition="wide diagonal shoreline composition",
+                prompt_version="test",
+                history_path=history_path,
+                allow_composition_cooldown_relaxation=True,
+            )
+            assert scene_blocked.reason == "scene_cooldown"
+
+            perceptual = dedup_module.dhash_file(image_path)
+            near_history = [
+                {
+                    "date": "2026-08-14",
+                    "scene_family": "quiet_lagoon_coast",
+                    "composition": "open horizon with large sky",
+                    "sha256": "f" * 64,
+                    "perceptual_hash": perceptual,
+                }
+            ]
+            history_path.write_text(json.dumps(near_history), encoding="utf-8")
+            near_blocked = dedup_module.evaluate_kld_visual_candidate(
+                image_path,
+                date_value="2026-08-15",
+                target_date="2026-08-15",
+                post_type="evening",
+                scene_family="rainy_coastal_road",
+                composition="wide diagonal shoreline composition",
+                prompt_version="test",
+                history_path=history_path,
+                allow_composition_cooldown_relaxation=True,
+            )
+            assert near_blocked.reason == "near_duplicate"
+
+            dedup_module.inspect_kld_provider_image = lambda *args, **kwargs: Verdict(False, "screen_or_ui_chrome")
+            history_path.write_text("[]", encoding="utf-8")
+            content_blocked = dedup_module.evaluate_kld_visual_candidate(
+                image_path,
+                date_value="2026-08-15",
+                target_date="2026-08-15",
+                post_type="evening",
+                scene_family="rainy_coastal_road",
+                composition="wide diagonal shoreline composition",
+                prompt_version="test",
+                history_path=history_path,
+                allow_composition_cooldown_relaxation=True,
+            )
+            assert content_blocked.reason == "content_guard:screen_or_ui_chrome"
+        finally:
+            dedup_module.inspect_kld_provider_image = original_guard
 
 
 def secondary_backend_rotates_same_fresh_candidate_pool() -> None:
@@ -203,6 +431,9 @@ TESTS = [
     evening_prompt_is_scene_authoritative_and_summer_green,
     winter_evening_prompt_does_not_force_summer_green,
     storm_allocator_keeps_last_three_scenes_hard_blocked,
+    composition_exhaustion_relaxes_oldest_only,
+    relaxed_candidate_reaches_provider_and_marks_final_gate,
+    composition_relaxation_does_not_weaken_other_guards,
     secondary_backend_rotates_same_fresh_candidate_pool,
     final_scene_policy_is_hard_and_reasons_are_explicit,
 ]


### PR DESCRIPTION
## Scope
Fix the confirmed production defect where simultaneous hard scene-family and composition cooldowns can exhaust the weather-routed KLD visual candidate pool before either image provider is attempted.

## Root cause
The allocator applies both the last-3 scene-family cooldown and last-4 composition cooldown as strict pre-provider filters. Once production history occupies the available compatible compositions, `candidate_pool` can become empty, leaving Pollinations and Stable Horde with no candidate to try. The local informative cover can then also be rejected as a perceptual near-duplicate, producing text-only posts.

## Minimal fix
- keep strict scene + composition selection as the primary path;
- keep last-3 scene-family cooldown hard with no relaxation;
- only when strict selection yields zero candidates, relax composition cooldown oldest-first and stop at the first depth that restores at least one candidate;
- mark any such candidate explicitly in diagnostics;
- pass that explicit marker to the final dedup/policy gate;
- allow the final gate to ignore only `composition_cooldown` for that marked exhaustion candidate, while re-running scene/macro policy;
- content guard, exact duplicate, perceptual near-duplicate, scene-family cooldown and scene-macro cooldown remain hard.

## Unchanged
- scene catalog and weather-to-scene routing;
- PR #24 pine exclusions;
- provider order and provider implementations;
- local informative cover renderer;
- Telegram/publication logic;
- visual-history namespaces and cache-key contract;
- post text and workflows.

## Focused offline regression
Adds coverage for a production-like exhaustion state with three blocked scenes and four real blocked compositions, verifies oldest-only composition relaxation, verifies a provider attempt occurs for the marked candidate, and verifies scene/content/perceptual guards remain hard.

Base SHA: `0ca8f680d7cb1bdbb57c4665e09f45cf27331c42`

Only these files are changed:
- `tools/kld_visual_fixture_image.py`
- `kld_visual_dedup.py`
- `tools/test_kld_evening_allocator_policy.py`

No manual workflow dispatch, provider call, Telegram call, or other operational external API call was performed.