### PR TITLE
Migrate Gemini fallback to 3.7 Flash

### DIFF
--- a/gpt.py
+++ b/gpt.py
@@ -8,7 +8,7 @@ gpt.py
 - Порядок провайдеров: OpenAI → Gemini → Groq.
 - При 429/insufficient_quota у OpenAI отключаем OpenAI на весь текущий запуск,
   чтобы не «стучать» повторно в платный провайдер.
-- Gemini перебираем по списку моделей (как вы просили), а затем (если нужно) идём в Groq.
+- Gemini перебираем по стабильной цепочке primary → fallback, а затем (если нужно) идём в Groq.
 - Контракт gpt_blurb(culprit) сохранён: возвращает (summary: str, tips: List[str]).
 
 Важно про Gemini:
@@ -40,13 +40,13 @@ GROQ_KEY = (os.getenv("GROQ_API_KEY") or "").strip()
 # ── модели ───────────────────────────────────────────────────────────────────
 OPENAI_MODEL = (os.getenv("OPENAI_MODEL") or "gpt-4o-mini").strip()
 
-# Gemini: перебор моделей (как вы попросили)
-GEMINI_MODELS = [
-    "gemini-3-flash",
-    "gemini-3-pro",
-    "gemini-2.5-flash",
-    "gemini-3-flash-preview",
-]
+DEFAULT_GEMINI_MODEL = "gemini-3.7-flash"
+DEFAULT_GEMINI_FALLBACK_MODEL = "gemini-2.5-flash"
+GEMINI_MODEL = (os.getenv("GEMINI_MODEL") or DEFAULT_GEMINI_MODEL).strip() or DEFAULT_GEMINI_MODEL
+GEMINI_FALLBACK_MODEL = (
+    (os.getenv("GEMINI_FALLBACK_MODEL") or DEFAULT_GEMINI_FALLBACK_MODEL).strip()
+    or DEFAULT_GEMINI_FALLBACK_MODEL
+)
 
 DEFAULT_GROQ_MODEL = "openai/gpt-oss-120b"
 DEFAULT_GROQ_FALLBACK_MODEL = "openai/gpt-oss-20b"
@@ -65,6 +65,14 @@ def _unique_nonempty_models(*models: str) -> List[str]:
             out.append(model)
     return out
 
+
+# Gemini: stable primary first, then the configured fallback. GEMINI_MODELS can
+# prepend explicitly configured candidates without duplicating either default.
+GEMINI_MODELS = _unique_nonempty_models(
+    *((os.getenv("GEMINI_MODELS") or "").split(",")),
+    GEMINI_MODEL,
+    GEMINI_FALLBACK_MODEL,
+)
 
 # Groq: primary model first, then the configured fallback.
 GROQ_MODELS = _unique_nonempty_models(GROQ_MODEL, GROQ_FALLBACK_MODEL)
@@ -222,12 +230,17 @@ def gpt_complete(
 
             for mdl in candidates:
                 try:
-                    r = cli.chat.completions.create(
-                        model=mdl,
-                        messages=messages,
-                        temperature=temperature,
-                        max_tokens=max_tokens,
-                    )
+                    request = {
+                        "model": mdl,
+                        "messages": messages,
+                        "max_tokens": max_tokens,
+                    }
+                    # Gemini 3.x rejects the legacy temperature/top-p/top-k
+                    # controls. Keep temperature only for the 2.5 fallback,
+                    # which preserves the previous behavior there.
+                    if not mdl.startswith("gemini-3"):
+                        request["temperature"] = temperature
+                    r = cli.chat.completions.create(**request)
                     text = (r.choices[0].message.content or "").strip()
                     if text:
                         log.info("LLM: Gemini ok (model=%s)", mdl)

--- a/tools/test_groq_model_migration.py
+++ b/tools/test_groq_model_migration.py
@@ -18,6 +18,8 @@ if str(ROOT) not in sys.path:
 
 PRIMARY_MODEL = "openai/gpt-oss-120b"
 FALLBACK_MODEL = "openai/gpt-oss-20b"
+GEMINI_PRIMARY_MODEL = "gemini-3.7-flash"
+GEMINI_FALLBACK_MODEL = "gemini-2.5-flash"
 
 pendulum_stub = types.ModuleType("pendulum")
 pendulum_stub.DateTime = object
@@ -71,6 +73,9 @@ def _import_gpt_fresh():
     for name in (
         "OPENAI_API_KEY",
         "GEMINI_API_KEY",
+        "GEMINI_MODEL",
+        "GEMINI_FALLBACK_MODEL",
+        "GEMINI_MODELS",
         "GROQ_API_KEY",
         "GROQ_MODEL",
         "GROQ_FALLBACK_MODEL",
@@ -103,6 +108,29 @@ class _FakeGroqClient:
         )
 
 
+class _FakeGeminiClient:
+    def __init__(self, failures: set[str]) -> None:
+        self.failures = failures
+        self.calls: list[dict] = []
+        self.models = SimpleNamespace(
+            list=lambda: SimpleNamespace(
+                data=[
+                    SimpleNamespace(id=GEMINI_PRIMARY_MODEL),
+                    SimpleNamespace(id=GEMINI_FALLBACK_MODEL),
+                ]
+            )
+        )
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+
+    def create(self, **request):
+        self.calls.append(request)
+        if request["model"] in self.failures:
+            raise RuntimeError("model not found")
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="Gemini fallback text"))]
+        )
+
+
 def _force_groq_only(gpt, client: _FakeGroqClient) -> None:
     gpt.OPENAI_KEY = ""
     gpt.GEMINI_KEY = ""
@@ -120,6 +148,41 @@ def test_default_groq_model_config() -> None:
     assert gpt.GROQ_MODEL == PRIMARY_MODEL
     assert gpt.GROQ_FALLBACK_MODEL == FALLBACK_MODEL
     assert gpt.GROQ_MODELS == [PRIMARY_MODEL, FALLBACK_MODEL]
+
+
+def test_default_gemini_model_config() -> None:
+    gpt = _import_gpt_fresh()
+    assert gpt.GEMINI_MODEL == GEMINI_PRIMARY_MODEL
+    assert gpt.GEMINI_FALLBACK_MODEL == GEMINI_FALLBACK_MODEL
+    assert gpt.GEMINI_MODELS == [GEMINI_PRIMARY_MODEL, GEMINI_FALLBACK_MODEL]
+
+
+def test_gemini_37_falls_back_without_legacy_sampling_controls() -> None:
+    gpt = _import_gpt_fresh()
+    client = _FakeGeminiClient(failures={GEMINI_PRIMARY_MODEL})
+    gpt.OPENAI_KEY = ""
+    gpt.GEMINI_KEY = "test"
+    gpt.GROQ_KEY = ""
+    gpt._OPENAI_DISABLED_FOR_RUN = False
+    gpt._GEMINI_DISABLED_FOR_RUN = False
+    gpt._GEMINI_MODEL_SET = None
+    gpt._gemini_openai_compat_client = lambda: client
+
+    text = gpt.gpt_complete("test prompt", temperature=0.7, max_tokens=80)
+
+    assert text == "Gemini fallback text"
+    assert [call["model"] for call in client.calls] == [GEMINI_PRIMARY_MODEL, GEMINI_FALLBACK_MODEL]
+    primary_request, fallback_request = client.calls
+    assert "temperature" not in primary_request
+    assert "top_p" not in primary_request
+    assert "top_k" not in primary_request
+    assert fallback_request["temperature"] == 0.7
+
+
+def test_removed_gemini_preview_ids_are_not_runtime_candidates() -> None:
+    runtime = (ROOT / "gpt.py").read_text(encoding="utf-8")
+    removed = ("gemini-" + "3-flash", "gemini-" + "3-pro", "gemini-" + "3-flash-preview")
+    assert not [model for model in removed if model in runtime]
 
 
 def test_primary_failure_attempts_fallback_model() -> None:
@@ -214,6 +277,9 @@ def main() -> None:
     tests = [
         test_no_deprecated_model_ids_in_runtime_files,
         test_default_groq_model_config,
+        test_default_gemini_model_config,
+        test_gemini_37_falls_back_without_legacy_sampling_controls,
+        test_removed_gemini_preview_ids_are_not_runtime_candidates,
         test_primary_failure_attempts_fallback_model,
         test_total_groq_failure_uses_local_blurb_fallback,
         kld_missing_core_morning_fails_closed,


### PR DESCRIPTION
## What
- use stable `gemini-3.7-flash` as the primary Gemini model
- retain stable `gemini-2.5-flash` as the fallback
- remove obsolete preview/unsupported Gemini candidates
- omit legacy sampling controls for Gemini 3.x while preserving fallback behavior
- add offline regression coverage for model order and request payloads

## Verification
- `git diff --check`
- Python compile check for changed code and tests
- full `tools/test_groq_model_migration.py` offline suite passed

The head commit uses `[skip ci]` because this repository's PR smoke workflow may collect live external data even in dry-run mode.

No provider calls, workflow dispatches, deployments, generation, Telegram sends, or publishing were performed.