### PR TITLE
fix: tighten KLD text contracts

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -55,7 +55,7 @@ jobs:
           GROQ_API_KEY: ""
           TELEGRAM_TOKEN: ""
           TELEGRAM_BOT_TOKEN: ""
-          TELEGRAM_TOKEN_KLG: ""
+          TELEGRAM_TOKEN_KLG: "test-token"
           POLLINATIONS_TOKEN: ""
           POLLINATIONS_API_KEY: ""
           HTTP_PROXY: http://127.0.0.1:9

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -48,6 +48,24 @@ jobs:
               suite[check]()
           print("OK: Gemini migration offline checks passed")
           PY
+      - name: KLD FORMAT_V2 text regressions (offline)
+        env:
+          OPENAI_API_KEY: ""
+          GEMINI_API_KEY: ""
+          GROQ_API_KEY: ""
+          TELEGRAM_TOKEN: ""
+          TELEGRAM_BOT_TOKEN: ""
+          TELEGRAM_TOKEN_KLG: ""
+          POLLINATIONS_TOKEN: ""
+          POLLINATIONS_API_KEY: ""
+          HTTP_PROXY: http://127.0.0.1:9
+          HTTPS_PROXY: http://127.0.0.1:9
+          ALL_PROXY: http://127.0.0.1:9
+          NO_PROXY: localhost,127.0.0.1
+        run: |
+          set -euo pipefail
+          python tools/test_format_v2_evening_kld.py
+          python tools/test_format_v2_morning_kld.py
       - name: Smoke daily (dry-run)
         env:
           TELEGRAM_TOKEN_KLG: "test"

--- a/post_common.py
+++ b/post_common.py
@@ -2294,7 +2294,7 @@ def build_message_legacy_evening(
             P.append(f"   • {city}: {d:.0f}/{n:.0f}{NBSP}°C" + (f" • {descx}" if descx else ""))
 
         P.append("❄️ <b>Холодные города, °C (топ-3)</b>")
-        for city, (d, n, wcx) in sorted(temps_oth.items(), key=lambda kv: kv[1][0])[:3]:
+        for city, (d, n, wcx) in sorted(temps_oth.items(), key=lambda kv: kv[1][1])[:3]:
             descx = code_desc(wcx)
             P.append(f"   • {city}: {d:.0f}/{n:.0f}{NBSP}°C" + (f" • {descx}" if descx else ""))
 

--- a/safe_test_post.py
+++ b/safe_test_post.py
@@ -383,6 +383,8 @@ def _kld_evening_score_line(v2_text: str) -> str:
     low = text.lower()
     conditions = _kld_conditions(v2_text)
     max_t = conditions.get("tmax")
+    cold_temps = _numbers(r"(-?\d+(?:[\.,]\d+)?)\s*°", text)
+    cold_max = max(cold_temps) if cold_temps else None
     # storm gust via the single shared parser: only "порыв …", never avg wind.
     max_gust = extract_max_gust_ms(text)
     visibility = visibility_condition_from_text(text)
@@ -409,9 +411,10 @@ def _kld_evening_score_line(v2_text: str) -> str:
             score -= 1.2; reasons.append("жара")
         elif max_t >= 30:
             score -= 0.6; reasons.append("жарко")
-        if max_t <= 14:
+    if isinstance(cold_max, (int, float)):
+        if cold_max <= 14:
             score -= 0.9; reasons.append("прохладно")
-        elif max_t <= 17:
+        elif cold_max <= 17:
             score -= 0.5; reasons.append("свежо")
     if "локально" in low or "неравномерно" in low:
         score -= 0.2; reasons.append("локальность прогноза")

--- a/safe_test_post.py
+++ b/safe_test_post.py
@@ -1503,7 +1503,7 @@ class _TodayPatch:
         if self._orig_today:
             pendulum.today = self._orig_today  # type: ignore[assignment]
         if self._orig_now:
-            pendulum.now = self._orig_now  # type: ignore[assignment]
+            pendulum.now = self._orig_now      # type: ignore[assignment]
         return False
 
 

--- a/safe_test_post.py
+++ b/safe_test_post.py
@@ -443,7 +443,7 @@ def _translate_shore_notes(text: str) -> str:
             return f"({direction})"
         return match.group(0)
 
-    return re.sub(r"\((N|NE|E|SE|S|SW|W|NW)/(None)\)\", repl, str(text or ""), flags=re.I)
+    return re.sub(r"\((N|NE|E|SE|S|SW|W|NW)/(None)\)", repl, str(text or ""), flags=re.I)
 
 
 def _fmt_num(value: float) -> str:

--- a/safe_test_post.py
+++ b/safe_test_post.py
@@ -381,8 +381,8 @@ def _kld_score_line(v2_text: str) -> str:
 def _kld_evening_score_line(v2_text: str) -> str:
     text = _plain(v2_text)
     low = text.lower()
-    temps = _numbers(r"(-?\d+(?:[\.,]\d+)?)\s*°", text)
-    max_t = max(temps) if temps else None
+    conditions = _kld_conditions(v2_text)
+    max_t = conditions.get("tmax")
     # storm gust via the single shared parser: only "порыв …", never avg wind.
     max_gust = extract_max_gust_ms(text)
     visibility = visibility_condition_from_text(text)
@@ -405,6 +405,10 @@ def _kld_evening_score_line(v2_text: str) -> str:
     elif "ветер" in low or "порыв" in low:
         score -= 0.4; reasons.append("ветер у воды")
     if isinstance(max_t, (int, float)):
+        if max_t >= 35:
+            score -= 1.2; reasons.append("жара")
+        elif max_t >= 30:
+            score -= 0.6; reasons.append("жарко")
         if max_t <= 14:
             score -= 0.9; reasons.append("прохладно")
         elif max_t <= 17:
@@ -417,11 +421,15 @@ def _kld_evening_score_line(v2_text: str) -> str:
         reasons.append(visibility_reason(visibility))
 
     score = max(1.0, min(10.0, score))
+    if isinstance(max_t, (int, float)) and max_t >= 35:
+        score = min(score, 7.9)
     label = _score_label(score)
     if has_warning or (isinstance(max_gust, (int, float)) and max_gust >= STORM_GUST_MS):
         if has_precip:
             return f"✨ VayboMeter завтра: {score:.1f}/10 — неустойчивый день: локальные осадки и штормовые порывы."
         return f"✨ VayboMeter завтра: {score:.1f}/10 — день с повышенной осторожностью: штормовые порывы."
+    if isinstance(max_t, (int, float)) and max_t >= 35:
+        return f"✨ VayboMeter завтра: {score:.1f}/10 — с оговорками; жара."
     if reasons:
         return f"✨ VayboMeter завтра: {score:.1f}/10 — {label}; " + ", ".join(reasons[:3]) + "."
     return f"✨ VayboMeter завтра: {score:.1f}/10 — {label} для обычных дел и прогулок."
@@ -435,7 +443,7 @@ def _translate_shore_notes(text: str) -> str:
             return f"({direction})"
         return match.group(0)
 
-    return re.sub(r"\((N|NE|E|SE|S|SW|W|NW)/(None)\)", repl, str(text or ""), flags=re.I)
+    return re.sub(r"\((N|NE|E|SE|S|SW|W|NW)/(None)\)\", repl, str(text or ""), flags=re.I)
 
 
 def _fmt_num(value: float) -> str:

--- a/safe_test_post.py
+++ b/safe_test_post.py
@@ -297,6 +297,8 @@ def _kld_smart_plan_line(v2_text: str) -> str:
         return "✅ План: дождевик и закрытая обувь; у моря выбирать защищённый маршрут."
     if has_rain:
         return "✅ План: зонт или дождевик, закрытая обувь; дела лучше короткими выходами между дождём."
+    if windy and isinstance(tmax, (int, float)) and tmax >= 28:
+        return "✅ План: прогулку лучше утром/вечером; днём — вода и тень, у воды учитывать ветер."
     if windy:
         return "✅ План: ветровка/слой; прогулку лучше в защищённых местах."
     if isinstance(uv, (int, float)) and uv >= 6:
@@ -1413,7 +1415,20 @@ def _inject_evening_score(v2_text: str, mode: str) -> str:
         return v2_text
     if any("VayboMeter" in line and "/10" in line for line in str(v2_text or "").splitlines()):
         return v2_text
-    return _insert_before_anchor(v2_text, _kld_evening_score_line(v2_text), ("🎯 <b>Уверенность", "🎯"))
+    return _insert_before_anchor(
+        v2_text,
+        _kld_evening_score_line(v2_text),
+        (
+            "🧭 Главное завтра:",
+            "⚠️ Нюанс:",
+            "⚠️ Главный нюанс:",
+            "🎯 <b>Уверенность",
+            "🎯",
+            "🏙️ Калининград",
+            "🏙 Калининград",
+            "#",
+        ),
+    )
 
 
 def _inject_morning_smart_plan(v2_text: str, mode: str) -> str:
@@ -1488,7 +1503,7 @@ class _TodayPatch:
         if self._orig_today:
             pendulum.today = self._orig_today  # type: ignore[assignment]
         if self._orig_now:
-            pendulum.now = self._orig_now      # type: ignore[assignment]
+            pendulum.now = self._orig_now  # type: ignore[assignment]
         return False
 
 

--- a/tools/test_format_v2_evening_kld.py
+++ b/tools/test_format_v2_evening_kld.py
@@ -875,6 +875,118 @@ def kld_evening_safe_postprocess_keeps_hashtags_final_and_dedupes_nuance() -> No
     assert not any(line.startswith("⚠️ Главный нюанс:") for line in lines[tag_index + 1:])
 
 
+def kld_evening_score_injection_survives_hashtag_finalizer() -> None:
+    source = NORMAL_EVENING.replace(
+        "✨ VayboMeter завтра: 8.1/10 — хороший день; берег свежее, восток теплее.\n",
+        "",
+    )
+    text = build_evening_format_v2("Калининградская область", source)
+    assert not any("VayboMeter" in line and "/10" in line for line in text.splitlines())
+
+    old = os.environ.get("EVENING_VAYBOMETER_SCORE")
+    try:
+        os.environ["EVENING_VAYBOMETER_SCORE"] = "1"
+        polished = _apply_format_v2_safe_postprocess(text, "", "", "evening")
+    finally:
+        if old is None:
+            os.environ.pop("EVENING_VAYBOMETER_SCORE", None)
+        else:
+            os.environ["EVENING_VAYBOMETER_SCORE"] = old
+
+    lines = [line.strip() for line in polished.splitlines() if line.strip()]
+    scores = [line for line in lines if "VayboMeter" in line and "/10" in line]
+    assert len(scores) == 1, scores
+    tag_index = lines.index("#Калининград #погода #здоровье #море")
+    assert lines.index(scores[0]) < tag_index
+    assert tag_index == len(lines) - 1
+
+
+def kld_evening_production_ranks_coolest_nights_by_tmin() -> None:
+    post_common = importlib.import_module("post_common")
+    original_day_offset = post_common.DAY_OFFSET
+    original_astro_offset = post_common.ASTRO_OFFSET
+    patched_names = (
+        "pendulum",
+        "get_sunrise_sunset",
+        "get_weather",
+        "day_night_stats",
+        "pick_tomorrow_header_metrics",
+        "storm_flags_for_tomorrow",
+        "fetch_tomorrow_temps",
+        "build_astro_section",
+        "get_air",
+        "get_schumann_with_fallback",
+        "_kld_visibility_for_post",
+        "_kld_quake_line_24h",
+        "safe_tips",
+    )
+    originals = {name: getattr(post_common, name) for name in patched_names}
+    temps_by_lat = {
+        1.0: (24.0, 15.0),
+        2.0: (23.0, 9.0),
+        3.0: (22.0, 12.0),
+        4.0: (21.0, 8.0),
+    }
+
+    class _FakeTZ:
+        name = "Europe/Kaliningrad"
+
+    class _FakeDate:
+        def add(self, *, days: int = 0):
+            return self
+
+        def format(self, _pattern: str) -> str:
+            return "20.06.2026"
+
+        def to_date_string(self) -> str:
+            return "2026-06-20"
+
+    try:
+        post_common.DAY_OFFSET = 1
+        post_common.ASTRO_OFFSET = 1
+        post_common.pendulum = types.SimpleNamespace(
+            timezone=lambda _tz: _FakeTZ(),
+            today=lambda _tz=None: _FakeDate(),
+        )
+        post_common.get_sunrise_sunset = lambda *_args, **_kwargs: ("04:08", "21:33")
+        post_common.get_weather = lambda *_args, **_kwargs: {}
+        post_common.day_night_stats = lambda *_args, **_kwargs: {}
+        post_common.pick_tomorrow_header_metrics = lambda *_args, **_kwargs: (None, None, None, "→")
+        post_common.storm_flags_for_tomorrow = lambda *_args, **_kwargs: {"warning": False}
+        post_common.fetch_tomorrow_temps = lambda lat, _lon, tz=None: temps_by_lat[float(lat)]
+        post_common.build_astro_section = lambda *_args, **_kwargs: "📻 <b>Астрособытия</b>"
+        post_common.get_air = lambda *_args, **_kwargs: {}
+        post_common.get_schumann_with_fallback = lambda: {}
+        post_common._kld_visibility_for_post = lambda *_args, **_kwargs: (None, None)
+        post_common._kld_quake_line_24h = lambda: None
+        post_common.safe_tips = lambda _theme: []
+
+        text = post_common.build_message_legacy_evening(
+            "Калининградская область",
+            "Морские города",
+            [],
+            "Другие города",
+            [
+                ("A", (1.0, 1.0)),
+                ("B", (2.0, 2.0)),
+                ("C", (3.0, 3.0)),
+                ("D", (4.0, 4.0)),
+            ],
+            "Europe/Kaliningrad",
+        )
+    finally:
+        post_common.DAY_OFFSET = original_day_offset
+        post_common.ASTRO_OFFSET = original_astro_offset
+        for name, value in originals.items():
+            setattr(post_common, name, value)
+
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    warm_index = lines.index("🔥 <b>Тёплые города, °C (топ-3)</b>")
+    cold_index = lines.index("❄️ <b>Холодные города, °C (топ-3)</b>")
+    assert [line.split(":", 1)[0] for line in lines[warm_index + 1:warm_index + 4]] == ["• A", "• B", "• C"]
+    assert [line.split(":", 1)[0] for line in lines[cold_index + 1:cold_index + 4]] == ["• D", "• B", "• C"]
+
+
 def main() -> None:
     checks = (
         kld_evening_normal_no_generic_confidence,
@@ -914,6 +1026,8 @@ def main() -> None:
         kld_evening_fully_populated_astro_preserves_voc,
         kld_evening_safe_postprocess_preserves_storm_astro,
         kld_evening_safe_postprocess_keeps_hashtags_final_and_dedupes_nuance,
+        kld_evening_score_injection_survives_hashtag_finalizer,
+        kld_evening_production_ranks_coolest_nights_by_tmin,
     )
     for check in checks:
         check()

--- a/tools/test_format_v2_evening_kld.py
+++ b/tools/test_format_v2_evening_kld.py
@@ -901,6 +901,58 @@ def kld_evening_score_injection_survives_hashtag_finalizer() -> None:
     assert tag_index == len(lines) - 1
 
 
+def kld_evening_injected_score_accounts_for_daytime_extreme_heat_without_uv() -> None:
+    source = NORMAL_EVENING.replace(
+        "✨ VayboMeter завтра: 8.1/10 — хороший день; берег свежее, восток теплее.\n",
+        "",
+    ).replace(
+        "Погода: 🏙️ Калининград — 21/13 °C",
+        "Погода: 🏙️ Калининград — 38/26 °C",
+    )
+    text = build_evening_format_v2("Калининградская область", source)
+    assert not any("VayboMeter" in line and "/10" in line for line in text.splitlines())
+
+    old = os.environ.get("EVENING_VAYBOMETER_SCORE")
+    try:
+        os.environ["EVENING_VAYBOMETER_SCORE"] = "1"
+        polished = _apply_format_v2_safe_postprocess(text, "", "", "evening")
+    finally:
+        if old is None:
+            os.environ.pop("EVENING_VAYBOMETER_SCORE", None)
+        else:
+            os.environ["EVENING_VAYBOMETER_SCORE"] = old
+
+    lines = [line.strip() for line in polished.splitlines() if line.strip()]
+    scores = [line for line in lines if "VayboMeter" in line and "/10" in line]
+    assert len(scores) == 1, scores
+    score_line = scores[0]
+    score_value = float(score_line.split(":", 1)[1].split("/10", 1)[0].strip())
+    assert score_value < 8.0, score_line
+    assert "очень хороший" not in score_line
+    assert "жара" in score_line
+    assert "высокий УФ" not in score_line
+    tag_index = lines.index("#Калининград #погода #здоровье #море")
+    assert lines.index(score_line) < tag_index
+    assert tag_index == len(lines) - 1
+
+
+def kld_evening_score_accounts_for_daytime_heat_from_30_c() -> None:
+    warm29 = "🏙 Калининград — 29/20 °C."
+    hot32 = "🏙 Калининград — 32/20 °C."
+    score29 = safe_test_post._kld_evening_score_line(warm29)
+    score32 = safe_test_post._kld_evening_score_line(hot32)
+    value29 = float(score29.split(":", 1)[1].split("/10", 1)[0].strip())
+    value32 = float(score32.split(":", 1)[1].split("/10", 1)[0].strip())
+    assert round(value29 - value32, 1) == 0.6, (score29, score32)
+    assert "жарко" not in score29
+    assert "жарко" in score32
+
+
+def kld_evening_score_preserves_moderate_non_heat_contract() -> None:
+    score = safe_test_post._kld_evening_score_line("🏙 Калининград — 21/13 °C.")
+    assert score == "✨ VayboMeter завтра: 9.1/10 — очень хороший; прохладно."
+
+
 def kld_evening_production_ranks_coolest_nights_by_tmin() -> None:
     post_common = importlib.import_module("post_common")
     original_day_offset = post_common.DAY_OFFSET
@@ -1027,6 +1079,9 @@ def main() -> None:
         kld_evening_safe_postprocess_preserves_storm_astro,
         kld_evening_safe_postprocess_keeps_hashtags_final_and_dedupes_nuance,
         kld_evening_score_injection_survives_hashtag_finalizer,
+        kld_evening_injected_score_accounts_for_daytime_extreme_heat_without_uv,
+        kld_evening_score_accounts_for_daytime_heat_from_30_c,
+        kld_evening_score_preserves_moderate_non_heat_contract,
         kld_evening_production_ranks_coolest_nights_by_tmin,
     )
     for check in checks:

--- a/tools/test_format_v2_morning_kld.py
+++ b/tools/test_format_v2_morning_kld.py
@@ -818,6 +818,36 @@ def kld_morning_collector_uses_current_run_city_lists() -> None:
     assert offsets and set(offsets) == {0}
 
 
+def kld_morning_hot_windy_without_uv_does_not_recommend_layer() -> None:
+    no_uv_fixture = HOT_MORNING_FIXTURE.replace(
+        "Погода: 🏙️ Калининград — 38/26 °C",
+        "Погода: 🏙️ Калининград — 30/20 °C",
+    ).replace("☀️ УФ: 7 — высокий\n", "")
+    no_uv_text = build_morning_format_v2("Калининградская область", no_uv_fixture)
+    high_uv_text = build_morning_format_v2("Калининградская область", HOT_MORNING_FIXTURE)
+
+    old = os.environ.get("MORNING_SMART_PLAN")
+    try:
+        os.environ["MORNING_SMART_PLAN"] = "1"
+        no_uv_text = _inject_morning_smart_plan(no_uv_text, "morning")
+        high_uv_text = _inject_morning_smart_plan(high_uv_text, "morning")
+    finally:
+        if old is None:
+            os.environ.pop("MORNING_SMART_PLAN", None)
+        else:
+            os.environ["MORNING_SMART_PLAN"] = old
+
+    no_uv_plan = next(line for line in no_uv_text.splitlines() if line.startswith("✅ План:"))
+    assert "ветровка/слой" not in no_uv_plan
+    assert "утром/вечером" in no_uv_plan
+    assert "у воды учитывать ветер" in no_uv_plan
+    assert "SPF" not in no_uv_plan
+    assert "☀️ УФ" not in no_uv_text
+
+    high_uv_plan = next(line for line in high_uv_text.splitlines() if line.startswith("✅ План:"))
+    assert high_uv_plan == "✅ План: дела и прогулка утром/вечером; днём — вода, тень, SPF и короткие выходы."
+
+
 def kld_workflow_morning_schedule_is_earlier() -> None:
     workflow = (ROOT / ".github" / "workflows" / "daily_post_klg.yml").read_text(encoding="utf-8")
     assert "cron: '30 0 * * *'" in workflow
@@ -857,6 +887,7 @@ def main() -> None:
         kld_morning_structured_current_run_temperatures_survive_safe_pipeline,
         kld_morning_structured_daytime_only_uses_short_form,
         kld_morning_collector_uses_current_run_city_lists,
+        kld_morning_hot_windy_without_uv_does_not_recommend_layer,
         kld_workflow_morning_schedule_is_earlier,
         kld_morning_astro_block_has_sunset_if_available,
         kld_evening_astro_block_has_tomorrow_wording,


### PR DESCRIPTION
Stage T1: keep evening cold-city ranking keyed to nighttime minima, preserve injected evening VayboMeter score placement, avoid layer advice on hot windy no-UV mornings, add focused FORMAT_V2 regressions, and run the two text suites in offline PR CI.

Scope is limited to the five approved files. No production workflow dispatches or operational API calls were used.